### PR TITLE
limit questions per section server-side

### DIFF
--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -7,4 +7,16 @@ class AssessmentXml < ActiveRecord::Base
     where(kind: kind)
   end
 
+  def xml_with_limited_questions(per_section)
+    node = Nokogiri::XML(self.xml)
+
+    node.css('section section').each do |s|
+      while s.css('item').count > per_section
+        s.css('item')[rand(s.css('item').count)].remove
+      end
+    end
+
+    node.to_xml
+  end
+
 end

--- a/spec/controllers/api/assessments_controller_spec.rb
+++ b/spec/controllers/api/assessments_controller_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe Api::AssessmentsController, type: :controller do
         get 'show', format: :xml, id: @assessment.id
         expect(response).to have_http_status(200)
       end
+
+      it "should use the per_sec value on the settings" do
+        @assessment_xml.xml = open('./spec/fixtures/sections_assessment.xml').read
+        @assessment_xml.save!
+
+        @assessment.assessment_settings.create({per_sec: 1})
+
+        get :show, format: :xml, id: @assessment.id
+
+        node = Nokogiri::XML(response.body)
+        node.css('section section').each do |s|
+          expect(s.css('item').count).to eq 1
+        end
+      end
+
     end
   end
 

--- a/spec/controllers/assessments_controller_spec.rb
+++ b/spec/controllers/assessments_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe AssessmentsController, type: :controller do
         post :create, assessment: assessment
         result = Assessment.where({title: "test"}).first
         expect(result.license).to eq("foo license")
-        expect(result.keyword_list).to eq(["keywords","foo"])
+        expect(result.keyword_list.sort).to eq(["foo", "keywords"])
       end
 
       it "sets creates two assessment xmls" do

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe AssessmentXml do
+  before do
+    @xml = open('./spec/fixtures/sections_assessment.xml').read
+    @assessment_xml = AssessmentXml.new
+    @assessment_xml.xml = @xml
+  end
+
+  it "should lower the item count in the sections" do
+    node = Nokogiri::XML(@assessment_xml.xml_with_limited_questions(1))
+    node.css('section section').each do |s|
+      expect(s.css('item').count).to eq 1
+    end
+  end
+
+end


### PR DESCRIPTION
if this is done only client-side then a user
could see all the questions anyway.

Test Plan:
 * xml should be returned as normal if `per_sec` not set
 * when `per_sec` is set, the xml returned should only have that many items in each section
 * the front-end code trying to select items from the section should still work if there are more items in a section than `per_sec`