### PR TITLE
don't require api token for analytics sending

### DIFF
--- a/app/controllers/api/assessment_results_controller.rb
+++ b/app/controllers/api/assessment_results_controller.rb
@@ -1,4 +1,5 @@
 class Api::AssessmentResultsController < Api::ApiController
+  before_action :validate_token, except: :send_result_to_analytics
 
   # TODO Might have to cheat and make this a index or show so we can use a GET request to record the data. This will avoid cross origin issues.
   def create
@@ -21,6 +22,11 @@ class Api::AssessmentResultsController < Api::ApiController
   end
 
   def send_result_to_analytics
+    if request.headers["Authorization"].present? &&
+            request.headers["Authorization"] != "Bearer null"
+      return unless validate_token
+    end
+
     if @current_user = current_user
       res = @current_user.assessment_results.find(params[:assessment_result_id])
       assessment = res.assessment

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,8 +130,10 @@ class ApplicationController < ActionController::Base
         
         @user = User.find(decoded_token[0]['user_id'])
         sign_in(@user, :event => :authentication)
+        true
       rescue JWT::DecodeError, InvalidTokenError
         render :json => { :error => "Unauthorized: Invalid token." }, status: :unauthorized
+        false
       end
     end
 


### PR DESCRIPTION
this allows not logged in users taking formative
quizzes to have their results sent.

It is still required for summative analytics
messages though.