### PR TITLE
restrict xml fetching by attempt count

### DIFF
--- a/app/controllers/api/user_assessments_controller.rb
+++ b/app/controllers/api/user_assessments_controller.rb
@@ -4,9 +4,8 @@ class Api::UserAssessmentsController < Api::ApiController
     assessment = Assessment.find(params[:assessmentId])
     if assessment != nil
       @user_assessment = assessment.user_assessments.where(eid: params[:id]).first
-      if !@user_assessment.nil?
-        @user_assessment.attempts += 1
-        @user_assessment.save!
+      if !@user_assessment.nil? && assessment.kind != 'summative'
+        @user_assessment.increment_attempts!
       end
     end
     respond_with(:api, @user_assessment)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -48,14 +48,20 @@ class AssessmentsController < ApplicationController
       end
       @assessment_kind = @assessment.kind
       if params[:user_id].present?
+        oea_user_id = @user ? @user.id : nil
         @user_assessment = @assessment.user_assessments.where(eid: params[:user_id]).first
         if !@user_assessment.nil?
           @user_attempts = @user_assessment.attempts || 0
+          if oea_user_id && @user_assessment.user_id != oea_user_id
+            @user_assessment.user_id = oea_user_id
+            @user_assessment.save
+          end
         else
           @user_assessment = @assessment.user_assessments.create({
             :eid => params[:user_id],
             :lti_context_id => params[:context_id],
-            :attempts => 0
+            :attempts => 0,
+            :user_id => oea_user_id
             })
           @user_attempts = @user_assessment.attempts
         end

--- a/app/models/user_assessment.rb
+++ b/app/models/user_assessment.rb
@@ -1,4 +1,13 @@
 class UserAssessment < ActiveRecord::Base
   belongs_to :user
   belongs_to :assessment
+
+  def increment_attempts!
+    self.attempts += 1
+    if self.attempts == 1
+      self.first_attempt_at = Time.now
+    end
+    self.most_recent_attempt_at = Time.now
+    self.save!
+  end
 end


### PR DESCRIPTION
If the user has passed the allowed attempt count
they can't get the xml from the server.

Incrementing the count for summative quizzes
now happens when the xml is fetched.