### PR TITLE
Student results

### DIFF
--- a/app/controllers/assessment_results_controller.rb
+++ b/app/controllers/assessment_results_controller.rb
@@ -5,12 +5,12 @@ class AssessmentResultsController < ApplicationController
     if params[:id].present? && params[:id].to_i > 0
       # The assessment lives in OEA
       @assessment = Assessment.find(params[:id])
-      @assessment_results = AssessmentResult.where(assessment_id: @assessment.id) 
+      @assessment_results = AssessmentResult.where(assessment_id: @assessment.id)
     else
       # The assessment does not live in OEA
       @assessment_query = query(:identifier) || query(:eid) || query(:src_url)
       render nothing: true, status: :not_acceptable and return if @assessment_query.blank?
-      @assessment_results = AssessmentResult.where(@assessment_query)  
+      @assessment_results = AssessmentResult.where(@assessment_query)
     end
 
     @item_results = ItemResult.where(assessment_result_id: @assessment_results.map(&:id))

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -74,7 +74,7 @@ class AssessmentsController < ApplicationController
         end
       end
 
-      if @user_assessment.assessment_results.by_status_final.any? && @assessment_settings.show_recent_results == true
+      if @user && @user_assessment.assessment_results.by_status_final.any? && @assessment_settings.show_recent_results == true
         @show_recent_results = true
       else
         @show_recent_results = false

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -4,7 +4,7 @@ require 'lti_role_helper'
 class AssessmentsController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  
+
   before_filter :skip_trackable
   before_filter :authenticate_user!, only: [:new, :create, :destroy]
   before_filter :check_lti, only: [:show, :lti]
@@ -46,7 +46,7 @@ class AssessmentsController < ApplicationController
         @style = @style != "" ? @style : @assessment_settings[:style] || ""
         @enable_start = params[:enable_start] ?  @enable_start : @assessment_settings[:enable_start] || false
         @confidence_levels = params[:confidence_levels] ?  @confidence_levels : @assessment_settings[:confidence_levels] || false
-        @per_sec = @per_sec ? @per_sec : @assessment_settings[:per_sec] || ""  
+        @per_sec = @per_sec ? @per_sec : @assessment_settings[:per_sec] || ""
       end
       @assessment_kind = @assessment.kind
       if params[:user_id].present?
@@ -73,6 +73,13 @@ class AssessmentsController < ApplicationController
           @user_attempts = @user_assessment.attempts
         end
       end
+
+      if @user_assessment.assessment_results.by_status_final.any? && @assessment_settings.show_recent_results == true
+        @show_recent_results = true
+      else
+        @show_recent_results = false
+      end
+
       @eid ||= @assessment.identifier
       if @embedded
         # Just show the assessment. This is here to support old style embed with id=# and embed=true

--- a/app/models/assessment_result.rb
+++ b/app/models/assessment_result.rb
@@ -69,7 +69,6 @@ class AssessmentResult < ActiveRecord::Base
     self.session_status == STATUS_PENDING_LTI_OUTCOME &&
             has_necessary_lti_data? &&
             self.assessment.summative? &&
-            self.lti_role != "admin" &&
             is_max_result?
   end
 

--- a/app/models/assessment_result.rb
+++ b/app/models/assessment_result.rb
@@ -91,4 +91,8 @@ class AssessmentResult < ActiveRecord::Base
     true
   end
 
+  def answered_question_ids
+    self.item_results.map(&:identifier)
+  end
+
 end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -21,4 +21,16 @@ class AssessmentXml < ActiveRecord::Base
     node.to_xml
   end
 
+  def xml_with_specific_items(assessment_result)
+   question_ids = assessment_result.answered_question_ids
+
+  node = Nokogiri::XML(self.xml)
+
+   node.css('item').each do |i|
+     if !question_ids.member?(i['ident'])
+       i.remove
+     end
+   end
+   node.to_xml
+ end
 end

--- a/app/views/assessments/_assessment_setup.html.erb
+++ b/app/views/assessments/_assessment_setup.html.erb
@@ -48,6 +48,7 @@
     <% if @user_assessment %>
     user_assessment_id: '<%= @user_assessment.id %>',
     <% end -%>
+    show_recent_results: <%= @show_recent_results %>,
     lti_role: "<%= @lti_role %>",
     lis_result_sourcedid: '<%= params[:lis_result_sourcedid] %>',
     lis_outcome_service_url: '<%= params[:lis_outcome_service_url] %>',

--- a/app/views/assessments/_assessment_setup.html.erb
+++ b/app/views/assessments/_assessment_setup.html.erb
@@ -48,7 +48,9 @@
     <% if @user_assessment %>
     user_assessment_id: '<%= @user_assessment.id %>',
     <% end -%>
+    <% if @show_recent_results %>
     show_recent_results: <%= @show_recent_results %>,
+    <% end -%>
     lti_role: "<%= @lti_role %>",
     lis_result_sourcedid: '<%= params[:lis_result_sourcedid] %>',
     lis_outcome_service_url: '<%= params[:lis_outcome_service_url] %>',

--- a/client/js/actions/assessment.js
+++ b/client/js/actions/assessment.js
@@ -7,11 +7,11 @@ import Dispatcher  from   "../dispatcher";
 export default {
 
   loadAssessment(settings, srcData){
-    
+
     if(srcData){
       srcData = srcData.trim();
       if(srcData.length > 0){
-        Dispatcher.dispatch({ 
+        Dispatcher.dispatch({
           action: Constants.ASSESSMENT_LOADED,
           settings: settings,
           data: {
@@ -64,7 +64,7 @@ export default {
   selectConfidenceLevel(level, index){
     Dispatcher.dispatch({action: Constants.LEVEL_SELECTED, level: level, index: index});
   },
-  
+
   submitAssessment(identifier, assessmentId, questions, studentAnswers, settings, outcomes){
     Dispatcher.dispatch({action: Constants.ASSESSMENT_SUBMITTED});
     // Only send data needed for server-side grading.
@@ -115,7 +115,7 @@ export default {
   retakeAssessment(){
     Dispatcher.dispatch({action: Constants.RETAKE_ASSESSMENT})
   },
-  
+
   assessmentViewed(settings, assessment){
     var body = {
       assessment_result : {
@@ -159,5 +159,5 @@ export default {
     };
     Api.post(Constants.ASSESSMENT_VIEWED, '/api/item_results', body);
   }
-  
+
 };

--- a/client/js/actions/review_assessment.js
+++ b/client/js/actions/review_assessment.js
@@ -17,9 +17,13 @@ export default {
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);
   },
 
-  loadAssessmentResult(assessmentId, resultId){
+  loadAssessmentResult(assessmentId, resultId, contextId=null){
     Dispatcher.dispatch({ action: Constants.REVIEW_RESULT_LOAD_PENDING });
-    Api.get(Constants.REVIEW_RESULT_LOADED, "/api/assessments/" + assessmentId + "/results/" + resultId);
+    if(contextId){
+      Api.get(Constants.REVIEW_RESULT_LOADED, "/api/assessments/" + assessmentId + "/results/" + resultId + "?lti_context_id=" + contextId);
+    }else{
+      Api.get(Constants.REVIEW_RESULT_LOADED, "/api/assessments/" + assessmentId + "/results/" + resultId);
+    }
   }
 
 };

--- a/client/js/components/assessment_results/assessment_result.jsx
+++ b/client/js/components/assessment_results/assessment_result.jsx
@@ -91,4 +91,3 @@ AssessmentResult.contextTypes = {
   theme: React.PropTypes.object,
   router: React.PropTypes.func
 };
-

--- a/client/js/components/assessment_results/item_result.jsx
+++ b/client/js/components/assessment_results/item_result.jsx
@@ -6,7 +6,7 @@ import ResultConfidence from './result_confidence';
 import ResultOutcome    from "./result_outcome";
 
 export default class ItemResult extends React.Component{
-  
+
   getStyles(props, theme){
     var color;
     var border;
@@ -59,8 +59,10 @@ export default class ItemResult extends React.Component{
     };
   }
   render() {
+    var correctAnswers = ""
+    this.props.attemptId == "most_recent" ? correctAnswers = "" : correctAnswers = this.props.correctAnswers      
     var styles = this.getStyles(this.props, this.context.theme);
-    var correctMessage = "You were incorrect."; 
+    var correctMessage = "You were incorrect.";
     if(this.props.isCorrect == "partial"){
       correctMessage = "You were partially correct."
     } else if(this.props.isCorrect === true){
@@ -84,7 +86,7 @@ export default class ItemResult extends React.Component{
               </div>
             </div>
             <div>
-              <UniversalInput item={this.props.question} isResult={true} chosen={this.props.chosen} correctAnswers={this.props.correctAnswers}/>
+              <UniversalInput {...this.props} item={this.props.question} isResult={true} chosen={this.props.chosen} correctAnswers={correctAnswers}/>
             </div>
             <div style={styles.confidenceWrapper}>
               <ResultConfidence level={this.props.confidence} />
@@ -93,7 +95,7 @@ export default class ItemResult extends React.Component{
           <div className="col-md-3 col-sm-3 col-xs-3">
             <ResultOutcome outcomes={this.props.question.outcomes} correct={this.props.isCorrect} level={this.props.confidence}/>
           </div>
-        </div> 
+        </div>
         <div className="row">
         </div>
         <hr />

--- a/client/js/components/assessment_results/summative_result.jsx
+++ b/client/js/components/assessment_results/summative_result.jsx
@@ -1,12 +1,12 @@
 "use strict";
 
-import React            from 'react';
-import AssessmentActions    from "../../actions/assessment";
-import AssessmentStore      from "../../stores/assessment";
+import React                 from 'react';
+import AssessmentActions     from "../../actions/assessment";
+import AssessmentStore       from "../../stores/assessment";
 import ReviewAssessmentStore from "../../stores/review_assessment";
-import SettingsStore        from "../../stores/settings";
-import ItemResult           from "./item_result";
-import ResultSummary        from "./result_summary.jsx";
+import SettingsStore         from "../../stores/settings";
+import ItemResult            from "./item_result";
+import ResultSummary         from "./result_summary.jsx";
 
 export default class SummativeResult extends React.Component{
 
@@ -38,20 +38,20 @@ export default class SummativeResult extends React.Component{
                              index={index}
                              confidence={qr.confidence_level}
                              chosen={qr.responses_chosen}
-                             correctAnswers={question.correct}/>;
+                             correctAnswers={question.correct}
+                             {...this.props}/>;
         }
       });
 
     } else {
       return this.state.questions.map((question, index)=>{
-        return <ItemResult key={index} question={question} isCorrect={this.state.assessmentResult.correct_list[index]} index={index} confidence={this.state.assessmentResult.confidence_level_list[index]}/>;
+        return <ItemResult {...this.props} key={index} question={question} isCorrect={this.state.assessmentResult.correct_list[index]} index={index} confidence={this.state.assessmentResult.confidence_level_list[index]}/>;
       })
 
     }
   }
 
   render() {
-
     var errors = "";
     var styles = this.props.styles;
     var itemResults = this.getItemResults();

--- a/client/js/components/assessment_results/teacher_preview.jsx
+++ b/client/js/components/assessment_results/teacher_preview.jsx
@@ -38,8 +38,6 @@ export default class TeacherPreview extends BaseComponent{
   }
 
   getItemResults(){
-    //return <p>hi</p>;
-
     return ReviewAssessmentStore.allQuestions().map((question, index)=>{
         return <ItemResult key={index}
                            question={question}

--- a/client/js/components/assessment_results/teacher_review.jsx
+++ b/client/js/components/assessment_results/teacher_review.jsx
@@ -17,7 +17,7 @@ export default class TeacherReview extends BaseComponent{
     if(!ReviewAssessmentStore.isLoaded() && !ReviewAssessmentStore.isLoading()){
       ReviewAssessmentActions.loadAssessment(window.DEFAULT_SETTINGS);
     }
-    ReviewAssessmentActions.loadAssessmentResult(props.params.assessmentId, props.params.attempdId);
+    ReviewAssessmentActions.loadAssessmentResult(props.params.assessmentId, props.params.attemptId, props.params.contextId);
     this.state = this.getState();
   }
 
@@ -47,6 +47,7 @@ export default class TeacherReview extends BaseComponent{
 
 
     return <SummativeResult
+        {...this.props.params}
         styles={this.getStyles(this.context.theme)}
         context={this.context}
         isSummative={this.isSummative()}

--- a/client/js/components/assessments/check_understanding.jsx
+++ b/client/js/components/assessments/check_understanding.jsx
@@ -228,9 +228,19 @@ export default class CheckUnderstanding extends React.Component{
       )
     }
 
+    var recentResults = null
+    if(this.props.showRecentResults){
+      recentResults = (
+        <div style={styles.buttonGroup}>
+          <button className="btn btn-sm" style={styles.teacherButton}>View Recent Quiz Results</button>
+        </div>
+      )
+    }
+
     return (
       <div className="assessment_container" style={styles.assessmentContainer}>
         {teacherOptions}
+        {recentResults}
         <div className="question">
           <div className="header" style={styles.header}>
             <p>{this.props.name}</p>

--- a/client/js/components/assessments/check_understanding.jsx
+++ b/client/js/components/assessments/check_understanding.jsx
@@ -20,6 +20,11 @@ export default class CheckUnderstanding extends React.Component{
     this.context.router.transitionTo("teacher-preview", {contextId: this.props.externalContextId, assessmentId: this.props.assessmentId});
   }
 
+  reviewRecentAssessment(id){
+    // this.context.router.transitionTo("assessment-result");
+    this.context.router.transitionTo("student-review", {contextId: this.props.externalContextId, assessmentId: this.props.assessmentId, attemptId: 'most_recent'});
+  }
+
   getStyles(props, theme){
     return {
       assessmentContainer:{
@@ -229,10 +234,10 @@ export default class CheckUnderstanding extends React.Component{
     }
 
     var recentResults = null
-    if(this.props.showRecentResults){
+    if(this.props.showRecentResults && this.props.ltiRole == "student"){
       recentResults = (
         <div style={styles.buttonGroup}>
-          <button className="btn btn-sm" style={styles.teacherButton}>View Recent Quiz Results</button>
+          <button className="btn btn-sm" style={styles.teacherButton} onClick={()=>{this.reviewRecentAssessment()}}>View Recent Quiz Results</button>
         </div>
       )
     }

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -101,7 +101,7 @@ export default class UniversalInput extends React.Component{
       case "multiple_choice_question":
       case "true_false_question":
         items = item.answers.map((answer) => {
-          return <RadioButton isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-radio" checked={this.wasChosen(answer.id)}  showAsCorrect={this.showAsCorrect(answer.id)}/>;
+          return <RadioButton {...this.props} isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-radio" checked={this.wasChosen(answer.id)}  showAsCorrect={this.showAsCorrect(answer.id)}/>;
         });
         break;
       case "edx_dropdown":
@@ -123,7 +123,7 @@ export default class UniversalInput extends React.Component{
         break;
       case "multiple_answers_question":
         items = item.answers.map((answer) => {
-          return <CheckBox isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-check" checked={this.wasChosen(answer.id)} showAsCorrect={this.showAsCorrect(answer.id)}/>;
+          return <CheckBox {...this.props} isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-check" checked={this.wasChosen(answer.id)} showAsCorrect={this.showAsCorrect(answer.id)}/>;
         });
         break;
       case "edx_image_mapped_input":

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -17,10 +17,10 @@ export default class CheckBox extends React.Component{
   checkedStatus(){
     var checked = null;
     var optionFlag = null;
-    if( this.props.checked === true ) {
-      checked = "true";
-    } else if ( this.props.checked === false ){
+    if ( this.props.checked === false || this.props.attemptId === "most_recent" ){
       checked = false;
+    } else if ( this.props.checked === true ){
+      checked = "true";
     } else if ( !this.props.isDisabled ) {
       checked = (AssessmentStore.studentAnswers() && AssessmentStore.studentAnswers().indexOf(this.props.item.id) > -1) ? "true" : null;
     }

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -16,10 +16,10 @@ export default class RadioButton extends React.Component{
   checkedStatus(){
     var checked = null;
     var optionFlag = null;
-    if( this.props.checked === true ) {
-      checked = "true";
-    } else if ( this.props.checked === false ){
+    if ( this.props.checked === false || this.props.attemptId === "most_recent" ){
       checked = false;
+    } else if( this.props.checked === true ) {
+      checked = "true";
     } else if ( !this.props.isDisabled ) {
       checked = (AssessmentStore.studentAnswers() && AssessmentStore.studentAnswers().indexOf(this.props.item.id) > -1) ? "true" : null;
     }

--- a/client/js/components/main/attempts.jsx
+++ b/client/js/components/main/attempts.jsx
@@ -33,7 +33,7 @@ export default class Attempts extends BaseComponent{
   }
 
   reviewAttempt(id){
-    this.context.router.transitionTo("teacher-review", {contextId: this.props.params.externalContextId, assessmentId: this.props.params.assessmentId, attempdId: id});
+    this.context.router.transitionTo("teacher-review", {contextId: this.props.params.externalContextId, assessmentId: this.props.params.assessmentId, attemptId: id});
   }
 
   attemptsStuff(ua){

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -89,20 +89,21 @@ export default class Start extends BaseComponent{
     var titleBar;
 
     if(this.state.showStart){
-        content         = <CheckUnderstanding
-        title           = {this.state.settings.assessmentTitle}
-        maxAttempts     = {this.state.settings.allowedAttempts}
-        userAttempts    = {this.state.settings.userAttempts}
-        eid             = {this.state.settings.lisUserId}
-        userId          = {this.state.settings.userId}
-        isLti           = {this.state.settings.isLti}
-        assessmentId    = {this.state.settings.assessmentId}
-        assessmentKind  = {this.state.settings.assessmentKind}
-        ltiRole         = {this.state.settings.ltiRole}
-        externalContextId = {this.state.settings.externalContextId}
-        accountId       = {this.state.settings.accountId}
-        icon            = {this.state.settings.images.QuizIcon_svg}/>;
-        progressBar     = <div style={styles.progressContainer}>
+        content            = <CheckUnderstanding
+        title              = {this.state.settings.assessmentTitle}
+        maxAttempts        = {this.state.settings.allowedAttempts}
+        userAttempts       = {this.state.settings.userAttempts}
+        eid                = {this.state.settings.lisUserId}
+        userId             = {this.state.settings.userId}
+        isLti              = {this.state.settings.isLti}
+        assessmentId       = {this.state.settings.assessmentId}
+        assessmentKind     = {this.state.settings.assessmentKind}
+        showRecentResults  = {this.state.settings.showRecentResults}
+        ltiRole            = {this.state.settings.ltiRole}
+        externalContextId  = {this.state.settings.externalContextId}
+        accountId          = {this.state.settings.accountId}
+        icon               = {this.state.settings.images.QuizIcon_svg}/>;
+        progressBar        = <div style={styles.progressContainer}>
                             <ProgressDropdown disabled={true} settings={this.state.settings} questions={this.state.allQuestions} currentQuestion={this.state.currentIndex + 1} questionCount={this.state.questionCount} />
                           </div>;
 

--- a/client/js/routes.jsx
+++ b/client/js/routes.jsx
@@ -8,7 +8,7 @@ import Start              from './components/main/start';
 import Attempts           from './components/main/attempts';
 import AssessmentResult   from './components/assessment_results/assessment_result';
 import TeacherReview      from './components/assessment_results/teacher_review';
-import TeacherPreview      from './components/assessment_results/teacher_preview';
+import TeacherPreview     from './components/assessment_results/teacher_preview';
 import Login              from './components/sessions/login';
 import Logout             from './components/sessions/logout';
 import Register           from './components/users/register';
@@ -27,7 +27,8 @@ var routes = (
     <DefaultRoute name="start" handler={Start} />
     <Route name="assessment" handler={Assessment}/>
     <Route name="assessment-result" handler={AssessmentResult}/>
-    <Route name="teacher-review" handler={TeacherReview}  path="review/:assessmentId/:attempdId" />
+    <Route name="student-review" handler={TeacherReview}  path="review/:assessmentId/:attemptId/:contextId" />
+    <Route name="teacher-review" handler={TeacherReview}  path="review/:assessmentId/:attemptId" />
     <Route name="teacher-preview" handler={TeacherPreview}  path="preview/:assessmentId" />
     <Route name="login" handler={Login}/>
     <Route name="register" handler={Register}/>

--- a/client/js/stores/settings.js
+++ b/client/js/stores/settings.js
@@ -51,7 +51,7 @@ function loadSettings(defaultSettings){
   _settings = {
     apiUrl             : bestValue('apiUrl', 'api_url', '/'),
     srcUrl             : bestValue('srcUrl', 'src_url'),
-    srcData            : srcData(), 
+    srcData            : srcData(),
     offline            : bestValue('offline', 'offline', false),
     assessmentId       : bestValue('assessmentId', 'assessment_id'),
     eId                : bestValue('eId', 'eid'),
@@ -77,7 +77,8 @@ function loadSettings(defaultSettings){
     ltiRole            : defaultSettings.lti_role,
     assessmentTitle    : defaultSettings.assessmentTitle,
     sectionCount       : parseInt(defaultSettings.sectionCount),
-    userAssessmentId   : bestValue('user_assessment_id', 'UserAssessmentId')
+    userAssessmentId   : bestValue('user_assessment_id', 'UserAssessmentId'),
+    showRecentResults  : defaultSettings.show_recent_results
   };
 
   if(!_settings.srcUrl && !_settings.offline){
@@ -122,4 +123,3 @@ Dispatcher.register(function(payload) {
 });
 
 export default SettingsStore;
-

--- a/db/migrate/20160118215331_add_student_view_results_to_assessment_settings.rb
+++ b/db/migrate/20160118215331_add_student_view_results_to_assessment_settings.rb
@@ -1,0 +1,5 @@
+class AddStudentViewResultsToAssessmentSettings < ActiveRecord::Migration
+  def change
+    add_column :assessment_settings, :show_recent_results, :boolean 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151023041958) do
+ActiveRecord::Schema.define(version: 20160118215331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,8 +75,8 @@ ActiveRecord::Schema.define(version: 20151023041958) do
   create_table "assessment_settings", force: :cascade do |t|
     t.integer  "assessment_id"
     t.integer  "allowed_attempts"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.string   "style"
     t.string   "per_sec"
     t.boolean  "confidence_levels"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20151023041958) do
     t.boolean  "is_default"
     t.integer  "account_id"
     t.string   "mode"
+    t.boolean  "show_recent_results"
   end
 
   create_table "assessment_xmls", force: :cascade do |t|

--- a/spec/factories/assessment_results.rb
+++ b/spec/factories/assessment_results.rb
@@ -2,6 +2,9 @@ FactoryGirl.define do
 
   factory :assessment_result do
     assessment
+    user
+    user_assessment
+		identifier 'fake_identifier'
   end
 
 end

--- a/spec/factories/user_assessments.rb
+++ b/spec/factories/user_assessments.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :user_assessment do
-    
+    assessment
+    user
+    attempts 3
+    eid 'fake_external_identifier'
+    lti_context_id 'fake_lti_context_id'
   end
 
 end

--- a/spec/models/assessment_result_spec.rb
+++ b/spec/models/assessment_result_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+describe AssessmentResult do
+
+  def create_assessment_result(user_assessment, score=100.0, attempt=0)
+    create(:assessment_result,
+         :external_user_id => user_assessment.eid,
+         :score => score,
+         :attempt => attempt,
+         :lti_outcome_data => {
+                 :lti_role => 'admin',
+                 :lis_user_id => user_assessment.eid,
+                 :lis_result_sourcedid => '',
+                 :lis_outcome_service_url => 'https://example.com/api/ltigrade_passback'
+         },
+         :user_assessment_id => user_assessment.id,
+         :session_status => 'pendingLtiOutcome'
+    )
+  end
+
+
+  before do
+    @user_assessment = create(:user_assessment)
+    @assessment_result_1 = create_assessment_result(@user_assessment, 33.0, 0)
+    @assessment_result_2 = create_assessment_result(@user_assessment, 67.0, 1)
+    @assessment_result_3 = create_assessment_result(@user_assessment, 16.0, 2)
+  end
+
+  context 'is_max_result?' do
+    it 'should return false if assessment_result is not the top score' do
+      expect(@assessment_result_1.is_max_result?).to eq false
+    end
+
+    it 'should return true if assessment_result is the top score' do
+      expect(@assessment_result_2.is_max_result?).to eq true
+    end
+
+    it 'should return false if assessment_result score is null' do
+      @assessment_result_2.score = nil
+      @assessment_result_2.save
+      expect(@assessment_result_2.is_max_result?).to eq false
+    end
+  end
+
+  context 'should_send_lti_outcome?' do
+    it 'should return false if any of the required fields are not present' do
+      @assessment_result_1.update(:score => nil)
+      expect(@assessment_result_1.has_necessary_lti_data?).to eq nil
+      @assessment_result_1.update(:score => 24.0, :lis_result_sourcedid => nil)
+      expect(@assessment_result_1.has_necessary_lti_data?).to eq nil
+      @assessment_result_1.update(:lis_result_sourcedid => "", :lis_outcome_service_url => nil)
+      expect(@assessment_result_1.has_necessary_lti_data?).to eq nil
+    end
+
+    it 'should return :lti_secret if all required fields are present' do
+      expect(@assessment_result_1.has_necessary_lti_data?).to eq @assessment_result_1.assessment.try(:account).try(:lti_secret)
+    end
+  end
+
+  context 'should_send_lti_outcome?' do
+    it 'should return false if session status is not pending lti outcome' do
+      @assessment_result_2.update(:session_status => 'initial')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+      @assessment_result_2.update(:session_status => 'pendingSubmission')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+      @assessment_result_2.update(:session_status => 'pendingResponseProcessing')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+      @assessment_result_2.update(:session_status => 'errorLtiOutcome')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+      @assessment_result_2.update(:session_status => 'final')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+    end
+
+    it 'should return nil if all necessarry lti data is not present' do
+      @assessment_result_2.update(:score => nil)
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq nil
+    end
+
+    it 'should return false if the assessment result is of the kind "formative"' do
+      @assessment_result_2.assessment.update(:kind => 'formative')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq false
+    end
+
+    it 'should return false if the assessment result is not the one with the highest score' do
+      expect(@assessment_result_1.should_send_lti_outcome?).to eq false
+    end
+
+    it 'should return true if the assessment result meets all the criteria' do
+      @assessment_result_2.assessment.update(:kind => 'summative')
+      expect(@assessment_result_2.should_send_lti_outcome?).to eq true
+    end
+  end
+
+  context 'post_lti_outcome' do
+    it 'should return true and change session_status to final if should_send_lti_outcome returns false or nil' do
+      @assessment_result_2.assessment.update(:kind => 'formative')
+      expect(@assessment_result_2.post_lti_outcome!).to eq true
+      expect(@assessment_result_2.session_status).to eq 'final'
+    end
+  end
+
+  context 'send_outcome_to_tool_consumer!' do
+  end
+
+end

--- a/spec/models/assessment_result_spec.rb
+++ b/spec/models/assessment_result_spec.rb
@@ -102,4 +102,11 @@ describe AssessmentResult do
   context 'send_outcome_to_tool_consumer!' do
   end
 
+  it "should return the question ids for questions answered" do
+    @item_result = create(:item_result, identifier: "4965")
+    @item_result2 = create(:item_result, identifier: "3790")
+    @assessment_result_1.update(item_results: [@item_result, @item_result2])
+    expect(@assessment_result_1.answered_question_ids).to eq ["4965", "3790"]
+  end
+
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 describe AssessmentXml do
   before do
-    @xml = open('./spec/fixtures/sections_assessment.xml').read
+    @xml = open('./spec/fixtures/swyk_quiz.xml').read
     @assessment_xml = AssessmentXml.new
     @assessment_xml.xml = @xml
+    @assessment = Assessment.create!(title: 'testing', xml_file: @xml )
+    @assessment_result = AssessmentResult.create!(assessment_id: @assessment.id)
+    @assessment_result = double("@assessment_result", :answered_question_ids => ["4965", "3790"])
   end
 
   it "should lower the item count in the sections" do
@@ -14,4 +17,15 @@ describe AssessmentXml do
     end
   end
 
+  it "should return xml with only the questions from the assessment result" do
+    node = Nokogiri::XML(@assessment_xml.xml_with_specific_items(@assessment_result))
+    node.css('item').each do |s|
+      expect(s['ident']).to_not eq "5555"
+    end
+  end
+
+  it "should return xml with only the questions from the assessment result" do
+    node = Nokogiri::XML(@assessment_xml.xml_with_specific_items(@assessment_result))
+    expect(node.css('item').map{|i|i['ident']}.sort).to eq ["3790", "4965"]
+  end
 end

--- a/spec/models/user_assessment_spec.rb
+++ b/spec/models/user_assessment_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe UserAssessment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe UserAssessment do
+
+	before do
+		@user_assessment = build(:user_assessment)
+	end
+	
 end


### PR DESCRIPTION
Student can now view a summary of the last assessment when:

-AssessmentSetting has show_recent_results set to true
-Their last assessment has session_status "final"

The students selection are not shown to them. They can determine that they selected a question right or wrong and can view how they rated their confidence for said question.

If the dependencies for the assessment review haven't been met the student cannot see their results nor will button for the summary be viewable. 
