### PR TITLE
Sanitize editing teacher's input

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem 'acts-as-taggable-on'
 gem 'nokogiri'
 gem 'nokogiri-happymapper', :require => 'happymapper'
 
+# sanitizing html
+gem 'rails-html-sanitizer'
+
 # Saml
 gem 'ruby-saml-mod'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,7 @@ DEPENDENCIES
   rack-cors
   rack-ssl-enforcer
   rails (= 4.2.1)
+  rails-html-sanitizer
   rails_12factor
   rails_apps_pages
   rails_apps_testing
@@ -438,4 +439,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/client/js/components/edit/question_interface/question_material.jsx
+++ b/client/js/components/edit/question_interface/question_material.jsx
@@ -21,7 +21,7 @@ export default class QuestionInterface extends BaseComponent{
         <div style={_.merge({paddingBottom: "0.25em"}, style.label)}>Question</div>
         <SimpleRCE
           content={this.props.material}
-          config="basic"
+          config={"sanitize_less"}
           onChange={this.props.onChange}
           />
       </div>

--- a/client/js/components/edit/question_interface/simple_rce.jsx
+++ b/client/js/components/edit/question_interface/simple_rce.jsx
@@ -54,7 +54,7 @@ export default class SimpleRCE extends BaseComponent {
         elementpath: false,
         content_css: '/assets/themes/lumen.css.scss',
         schema: 'html5',
-        extended_valid_elements: 'img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], abbr[*], audio[autoplay|controls|loop|muted|preload|src], span[*]'
+        extended_valid_elements: 'span[*], img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], abbr[*], audio[autoplay|controls|loop|muted|preload|src]'
       });
     } else {
       return({

--- a/client/js/components/edit/question_interface/simple_rce.jsx
+++ b/client/js/components/edit/question_interface/simple_rce.jsx
@@ -53,7 +53,8 @@ export default class SimpleRCE extends BaseComponent {
         statusbar: true,
         elementpath: false,
         content_css: '/assets/themes/lumen.css.scss',
-        extended_valid_elements: 'img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], a[href]'
+        schema: 'html5',
+        extended_valid_elements: 'img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], abbr[*], audio[autoplay|controls|loop|muted|preload|src], span[*]'
       });
     } else {
       return({

--- a/client/js/components/edit/question_interface/simple_rce.jsx
+++ b/client/js/components/edit/question_interface/simple_rce.jsx
@@ -54,7 +54,7 @@ export default class SimpleRCE extends BaseComponent {
         elementpath: false,
         content_css: '/assets/themes/lumen.css.scss',
         schema: 'html5',
-        extended_valid_elements: 'span[*], img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], abbr[*], audio[autoplay|controls|loop|muted|preload|src]'
+        extended_valid_elements: 'span[*], img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], abbr[*], audio[autoplay|controls|loop|muted|preload|src], caption[*]'
       });
     } else {
       return({

--- a/client/js/components/edit/question_interface/simple_rce.jsx
+++ b/client/js/components/edit/question_interface/simple_rce.jsx
@@ -41,6 +41,20 @@ export default class SimpleRCE extends BaseComponent {
         elementpath: false,
         content_css: '/assets/themes/lumen.css.scss'
       });
+    } else if (config === "sanitize_less") {
+      return({
+        toolbar: 'undo redo | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | table bullist numlist link image | code',
+        plugins: 'table, code, autoresize',
+        min_height: 100,
+        autoresize_bottom_margin: 10,
+        autoresize_max_height: 500,
+        autoresize_min_height: 100,
+        menubar: false,
+        statusbar: true,
+        elementpath: false,
+        content_css: '/assets/themes/lumen.css.scss',
+        extended_valid_elements: 'img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name], a[href]'
+      });
     } else {
       return({
         menubar: true,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,8 +79,8 @@ ActiveRecord::Schema.define(version: 20160801005426) do
   create_table "assessment_settings", force: :cascade do |t|
     t.integer  "assessment_id"
     t.integer  "allowed_attempts"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.string   "style"
     t.string   "per_sec"
     t.boolean  "confidence_levels"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20160801005426) do
     t.boolean  "is_default"
     t.integer  "account_id"
     t.string   "mode"
+    t.boolean  "show_recent_results"
   end
 
   create_table "assessment_xmls", force: :cascade do |t|

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -6,7 +6,7 @@ module Json2Qti
 
   def self.white_list_sanitize_html(html)
     white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
-    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br button caption center cite code col colgroup dd del dfn dir div dl dt em figure figcaption font form h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img input ins kbd label legend li map menu ol optgroup option p param pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(src style href height width))
+    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br caption center cite code col colgroup controls dd del dfn dir div dl dt em figure figcaption font h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img ins kbd label li map ol optgroup option p pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(controls type width height src style href coords alt shape title selected value name data autoplay loop muted preload dir label id cols col rows span))
     sanitized
   end
 

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -6,7 +6,7 @@ module Json2Qti
 
   def self.white_list_sanitize_html(html)
     white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
-    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br caption center cite code col colgroup controls dd del dfn dir div dl dt em figure figcaption font h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img ins kbd label li map ol optgroup option p pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(controls type width height src style href coords alt shape title selected value name data autoplay loop muted preload dir label id cols col rows span))
+    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br caption center cite code col colgroup controls dd del dfn dir div dl dt em figure figcaption font h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img ins kbd label li map ol p pre q s samp small source span strike strong sub sup table tbody td tfoot th thead tr track tt u ul var video), attributes: %w(controls type width height src style href coords alt shape title selected value name data autoplay loop muted preload dir label id cols col rows span))
     sanitized
   end
 

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -6,7 +6,7 @@ module Json2Qti
 
   def self.white_list_sanitize_html(html)
     white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
-    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br caption center cite code col colgroup controls dd del dfn dir div dl dt em figure figcaption font h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img ins kbd label li map ol p pre q s samp small source span strike strong sub sup table tbody td tfoot th thead tr track tt u ul var video), attributes: %w(controls type width height src style href coords alt shape title selected value name data autoplay loop muted preload dir label id cols col rows span))
+    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br caption center cite code col colgroup controls dd del dfn dir div dl dt em figure figcaption font h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img ins kbd label li map ol p pre q s samp small source span strike strong sub sup table tbody td tfoot th thead tr track tt u ul var video), attributes: %w(controls type width height src style href coords alt shape title selected value name data autoplay loop muted preload dir label id cols col rows span target))
     sanitized
   end
 

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -3,9 +3,21 @@ module Json2Qti
     j2q = Json2Qti::Converter.new(json, opts)
     j2q.convert_to_qti
   end
+  def self.sanitize_html(html)
+    full_sanitizer = Rails::Html::FullSanitizer.new
+    sanitized = full_sanitizer.sanitize(html)
+    sanitized
+  end
 end
 
 require 'json2qti/converter'
 require 'json2qti/question'
 require 'json2qti/multiple_choice'
 require 'json2qti/multiple_select'
+
+
+# full_sanitizer = Rails::Html::FullSanitizer.new
+# their use:  full_sanitizer.sanitize("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...")
+
+# @material = Json2Qti.sanitize(item["material"])
+# @answers = item["answers"].map{|a| a["material"] = Json2Qti.sanitize(a["material"]

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -3,11 +3,13 @@ module Json2Qti
     j2q = Json2Qti::Converter.new(json, opts)
     j2q.convert_to_qti
   end
-  def self.sanitize_html(html)
-    full_sanitizer = Rails::Html::FullSanitizer.new
-    sanitized = full_sanitizer.sanitize(html)
+
+  def self.white_list_sanitize_html(html)
+    white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
+    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br button caption center cite code col colgroup dd del dfn dir div dl dt em figure figcaption font form h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img input ins kbd label legend li map menu ol optgroup option p param pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(src style href))
     sanitized
   end
+
 end
 
 require 'json2qti/converter'
@@ -15,9 +17,4 @@ require 'json2qti/question'
 require 'json2qti/multiple_choice'
 require 'json2qti/multiple_select'
 
-
-# full_sanitizer = Rails::Html::FullSanitizer.new
-# their use:  full_sanitizer.sanitize("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...")
-
-# @material = Json2Qti.sanitize(item["material"])
-# @answers = item["answers"].map{|a| a["material"] = Json2Qti.sanitize(a["material"]
+# ones I question:  embed ins video track audio

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -16,5 +16,3 @@ require 'json2qti/converter'
 require 'json2qti/question'
 require 'json2qti/multiple_choice'
 require 'json2qti/multiple_select'
-
-# ones I question:  embed ins video track audio

--- a/lib/json2qti.rb
+++ b/lib/json2qti.rb
@@ -6,7 +6,7 @@ module Json2Qti
 
   def self.white_list_sanitize_html(html)
     white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
-    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br button caption center cite code col colgroup dd del dfn dir div dl dt em figure figcaption font form h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img input ins kbd label legend li map menu ol optgroup option p param pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(src style href))
+    sanitized = white_list_sanitizer.sanitize(html, tags: %w(a abbr acronym address area audio b bdo big blockquote br button caption center cite code col colgroup dd del dfn dir div dl dt em figure figcaption font form h1 h2 h3 h4 h5 h6 h7 h8 hr i iframe img input ins kbd label legend li map menu ol optgroup option p param pre q s samp select small source span strike strong sub sup table tbody td textarea tfoot th thead tr track tt u ul var video), attributes: %w(src style href height width))
     sanitized
   end
 

--- a/lib/json2qti/question.rb
+++ b/lib/json2qti/question.rb
@@ -4,11 +4,9 @@ module Json2Qti
 
     def initialize(item)
       @title = item["title"] || ''
-      # @material = item["material"] || ''
-      # @answers = item["answers"]
 
-      @material = Json2Qti::white_list_sanitize_html(item["material"]) # still need the || ''  ?
-      @answers = item["answers"].map{|a| a["material"] = Json2Qti::white_list_sanitize_html(a["material"]); a }
+      @material = Json2Qti::white_list_sanitize_html(item["material"]) || ''
+      @answers = item["answers"].map{|a| a["material"] = Json2Qti::white_list_sanitize_html(a["material"]) || ''; a }
 
       @id = item["id"]
       @key = [@material, @answers]

--- a/lib/json2qti/question.rb
+++ b/lib/json2qti/question.rb
@@ -4,8 +4,12 @@ module Json2Qti
 
     def initialize(item)
       @title = item["title"] || ''
-      @material = item["material"] || ''
-      @answers = item["answers"]
+      # @material = item["material"] || ''
+      # @answers = item["answers"]
+
+      @material = Json2Qti::white_list_sanitize_html(item["material"]) # still need the || ''  ?
+      @answers = item["answers"].map{|a| a["material"] = Json2Qti::white_list_sanitize_html(a["material"]); a }
+
       @id = item["id"]
       @key = [@material, @answers]
       @ident = generate_digest_ident(@key)

--- a/spec/lib/json2qti/json2qti_spec.rb
+++ b/spec/lib/json2qti/json2qti_spec.rb
@@ -80,5 +80,8 @@ describe Json2Qti do
     it "should not strip source or control attributes from audio files" do
       expect(Json2Qti.white_list_sanitize_html("<audio controls><source src='horse.ogg' type='audio/ogg'><source src='http://hubblesource.stsci.edu/sources/video/clips/details/images/centaur_1.mpg' type='audio/mpg'>Your browser does not support the audio tag.</audio>")).to eq "<audio controls><source src=\"horse.ogg\" type=\"audio/ogg\"><source src=\"http://hubblesource.stsci.edu/sources/video/clips/details/images/centaur_1.mpg\" type=\"audio/mpg\">Your browser does not support the audio tag.</source></source></audio>"
     end
+    it "should align right for right to left directional text" do
+      expect(Json2Qti.white_list_sanitize_html("<p style='text-align:right'><bdo dir='rtl'>write this backwards</bdo></p>")).to eq "<p style=\"text-align: right;\"><bdo dir=\"rtl\">write this backwards</bdo></p>"
+    end
   end
 end

--- a/spec/lib/json2qti/json2qti_spec.rb
+++ b/spec/lib/json2qti/json2qti_spec.rb
@@ -69,10 +69,16 @@ describe Json2Qti do
       </table>"
     end
     it "should not allow onclick type events or embeds" do
-      expect(Json2Qti.white_list_sanitize_html("<p id='demo' onclick='myFunction()'><embed src='helloworld.swf'>Click me to change <em>my</em> text color.</p>")).to eq "<p>Click me to change <em>my</em> text color.</p>"
+      expect(Json2Qti.white_list_sanitize_html("<p id='demo' onclick='myFunction()'><embed src='helloworld.swf'>Click me to change <em>my</em> text color.</p>")).to eq "<p id=\"demo\">Click me to change <em>my</em> text color.</p>"
     end
     it "should not strip any h or pre tags" do
       expect(Json2Qti.white_list_sanitize_html("<pre><h2>I am an h2 tag</h2></pre>")).to eq "<pre><h2>I am an h2 tag</h2></pre>"
+    end
+    it "should not strip title attributes" do
+      expect(Json2Qti.white_list_sanitize_html("<span title='my title'>I am a span with a title</span>")).to eq "<span title=\"my title\">I am a span with a title</span>"
+    end
+    it "should not strip source or control attributes from audio files" do
+      expect(Json2Qti.white_list_sanitize_html("<audio controls><source src='horse.ogg' type='audio/ogg'><source src='http://hubblesource.stsci.edu/sources/video/clips/details/images/centaur_1.mpg' type='audio/mpg'>Your browser does not support the audio tag.</audio>")).to eq "<audio controls><source src=\"horse.ogg\" type=\"audio/ogg\"><source src=\"http://hubblesource.stsci.edu/sources/video/clips/details/images/centaur_1.mpg\" type=\"audio/mpg\">Your browser does not support the audio tag.</source></source></audio>"
     end
   end
 end

--- a/spec/lib/json2qti/json2qti_spec.rb
+++ b/spec/lib/json2qti/json2qti_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'json2qti'
+
+describe Json2Qti do
+  context "#sanitize_html" do
+
+    it "should not change strings that aren't bad" do
+      expect(Json2Qti.sanitize_html("hi")).to eq "hi"
+    end
+
+    it "should filter out javascript" do
+      expect(Json2Qti.sanitize_html("hi<script>alert('gotcha')</script>")).to eq "hi"
+    end
+
+    it "should filter out links" do
+      expect(Json2Qti.sanitize_html("hi<a href=http://google.com> google</a>")).to eq "hi google"
+    end
+
+    it "should filter out images" do
+      expect(Json2Qti.sanitize_html("hi<img src=https://www.google.com/url?sa=i&rct=j&q=&esrc=s&source=images&cd=&ved=0ahUKEwia2ofdr4DPAhUD0GMKHUJEBYgQjRwIBw&url=http%3A%2F%2Farstechnica.com%2Fscience%2F2016%2F02%2Ftiny-blurry-pictures-find-the-limits-of-computer-image-recognition%2F&psig=AFQjCNF3V336JHjdGoorBg4IWVpETGS7MA&ust=1473444786714695>")).to eq "hi"
+    end
+
+    it "should filter out style tag" do
+      expect(Json2Qti.sanitize_html("hi<style>background-color: #fff</style>")).to eq "hibackground-color: #fff"
+    end
+
+    it "should filter out embedded tags" do
+      expect(Json2Qti.sanitize_html("hi<table><a href=http://lumenlearning.com> lumen</a></table>")).to eq "hi lumen"
+    end
+
+  end
+end

--- a/spec/lib/json2qti/question_spec.rb
+++ b/spec/lib/json2qti/question_spec.rb
@@ -17,7 +17,7 @@ describe Json2Qti::Question do
                     },
                     {
                             "id" => "4501",
-                            "material" => "&amp; Or this?",
+                            "material" => "<abbr title='Lumen'>LL</abbr> &amp; <span>Or this?</span>",
                             "isCorrect" => false
                     }
             ],
@@ -38,7 +38,7 @@ describe Json2Qti::Question do
 
   it "should escape question material" do
     expect(question.to_qti).to include(%{<mattext texttype="text/html">Which of the following? &amp;amp;</mattext>})
-    expect(question.to_qti).to include(%{<mattext texttype="text/html">&amp;amp; Or this?</mattext>})
+    expect(question.to_qti).to include(%{mattext texttype="text/html">&lt;abbr title=\"Lumen\"&gt;LL&lt;/abbr&gt; &amp;amp; &lt;span&gt;Or this?&lt;/span&gt;</mattext>})
     expect(question.to_qti).to include(%{<item title="This &amp; That"})
   end
 
@@ -54,5 +54,8 @@ describe Json2Qti::Question do
   it "should sanitize material" do
     expect(question.to_qti).to include(%{<mattext texttype="text/html">Which of the following? &amp;amp;</mattext>})
     expect(question.to_qti).to include(%{<mattext texttype="text/html">This?alert('sneakiness');&lt;p style=\"background-color: blue;\"&gt;blue&lt;/p&gt;</mattext>})
+  end
+  it "should not sanitize title or span" do
+    expect(question.to_qti).to include(%{mattext texttype="text/html">&lt;abbr title=\"Lumen\"&gt;LL&lt;/abbr&gt; &amp;amp; &lt;span&gt;Or this?&lt;/span&gt;</mattext>})
   end
 end

--- a/spec/lib/json2qti/question_spec.rb
+++ b/spec/lib/json2qti/question_spec.rb
@@ -8,16 +8,16 @@ describe Json2Qti::Question do
             "id" => "4965",
             "title" => "This & That",
             "question_type" => "multiple_choice_question",
-            "material" => "Which of the following? &",
+            "material" => "Which of the following? &amp;",
             "answers" => [
                     {
                             "id" => "9755",
-                            "material" => "This?",
+                            "material" => "This?<script>alert('sneakiness');</script><p style='background-color: blue'>blue</p>",
                             "isCorrect" => true
                     },
                     {
                             "id" => "4501",
-                            "material" => "& Or this?",
+                            "material" => "&amp; Or this?",
                             "isCorrect" => false
                     }
             ],
@@ -37,8 +37,8 @@ describe Json2Qti::Question do
   end
 
   it "should escape question material" do
-    expect(question.to_qti).to include(%{<mattext texttype="text/html">Which of the following? &amp;</mattext>})
-    expect(question.to_qti).to include(%{<mattext texttype="text/html">&amp; Or this?</mattext>})
+    expect(question.to_qti).to include(%{<mattext texttype="text/html">Which of the following? &amp;amp;</mattext>})
+    expect(question.to_qti).to include(%{<mattext texttype="text/html">&amp;amp; Or this?</mattext>})
     expect(question.to_qti).to include(%{<item title="This &amp; That"})
   end
 
@@ -49,5 +49,10 @@ describe Json2Qti::Question do
 
   it "should set the question type" do
     expect(question.to_qti).to include("<fieldentry>multiple_choice_question</fieldentry>")
+  end
+
+  it "should sanitize material" do
+    expect(question.to_qti).to include(%{<mattext texttype="text/html">Which of the following? &amp;amp;</mattext>})
+    expect(question.to_qti).to include(%{<mattext texttype="text/html">This?alert('sneakiness');&lt;p style=\"background-color: blue;\"&gt;blue&lt;/p&gt;</mattext>})
   end
 end

--- a/spec/lib/json2qti/question_spec.rb
+++ b/spec/lib/json2qti/question_spec.rb
@@ -19,6 +19,11 @@ describe Json2Qti::Question do
                             "id" => "4501",
                             "material" => "<abbr title='Lumen'>LL</abbr> &amp; <span>Or this?</span>",
                             "isCorrect" => false
+                    },
+                    {
+                            "id" => "4650",
+                            "material" => nil,
+                            "isCorrect" => nil
                     }
             ],
             "outcome" => {
@@ -57,5 +62,8 @@ describe Json2Qti::Question do
   end
   it "should not sanitize title or span" do
     expect(question.to_qti).to include(%{mattext texttype="text/html">&lt;abbr title=\"Lumen\"&gt;LL&lt;/abbr&gt; &amp;amp; &lt;span&gt;Or this?&lt;/span&gt;</mattext>})
+  end
+  it "should return nothing if material is nil" do
+    expect(question.to_qti).to include(%{mattext texttype="text/html"></mattext>})
   end
 end


### PR DESCRIPTION
- sanitizing html input in the front end with change to schema and extension of valid elements in simple_rce.jsx, and in the back end with white_list_sanitize_html in json2qti.rb
- html elements that allow input are sanitized.
- currently allowed html inputs include: 
  a, abbr, address, audio, b, big, blockquote, cite, code, col, colgroup, dd, div, dl, dt, del, dfn, div 
  em, fig, fig caption, h tags, hr, i, iframe, img, ins, kbd, p, pre, q, s, samp, small, source, span, strong, sub, sup, table, th, td, tr, tbody, thead, tfoot, track, u, var, video (gist of html elements and attributes for testing:  https://gist.github.com/kdv24/3711879697e3a9a8f307ebb51554f840
