### PR TITLE
Don't allow domains with trailing periods.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,10 +10,22 @@ else
   canvas_uri ||= 'https://atomicjolt.instructure.com'
 end
 
+# Ensure there are no trailing dots on domain names. See secrets.yml, "application_url" property.
+app_subdomain = ENV['APP_SUBDOMAIN']
+app_url = ENV['APP_URL']
+
+if app_subdomain.nil? || app_subdomain.empty?
+  first_account_domain = 'lvh.me'
+elsif app_url.nil? || app_url.empty?
+  first_account_domain = app_subdomain
+else
+  first_account_domain = app_subdomain + '.' + app_url
+end
+
 accounts = [{
   code: ENV["APP_SUBDOMAIN"],
   name: Rails.application.secrets.application_name,
-  domain: Rails.application.secrets.application_url,
+  domain: first_account_domain,
   lti_key: ENV["APP_SUBDOMAIN"],
   canvas_uri: canvas_uri
 }]


### PR DESCRIPTION
This change prevents the bug from happening.

__Note__: This only prevents the bug from occurring in `db/seeds.rb`. It does NOT address the issue anywhere else. (If secrets.yml is parsed elsewhere, the bug will still occur there)

An alternative solution is provided in the `trailing_period2` branch.
See the pull request for the `trailing_period2` branch before merging this.