### PR TITLE
If Beanstalk-specific DB env vars are missing, use user-defined env vars instead.

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -16,5 +16,9 @@ test:
 
 production:
   <<: *default
-  database: openassessments_production
-  username: openassessments
+  database: <%= ENV['RDS_DB_NAME'] || ENV['DB_NAME'] %>
+  username: <%= ENV['RDS_USERNAME'] || ENV['DB_USERNAME'] %>
+  password: <%= ENV['RDS_PASSWORD'] || ENV['DB_PASSWORD'] %>
+  host: <%= ENV['RDS_HOSTNAME'] || ENV['DB_SERVER'] %>
+  port: <%= ENV['RDS_PORT'] || 5432 %>
+


### PR DESCRIPTION
RDS_* env vars are provided by Beanstalk when an RDS instance is created inside
a Beanstalk environment.

This week, we moved our app servers into a new Beanstalk environment. At least
once, after manually defining those RDS_* env vars, they disappeared.

This change adds user-defined DB_* env vars as fallbacks to the RDS_* vars.

Eventually, we'll want to eliminate using the RDS_* env vars, since those are
normally controlled by Beanstalk.