### PR TITLE
[WIP] - Show Feedback on Self Checks

### DIFF
--- a/client/js/actions/assessment.js
+++ b/client/js/actions/assessment.js
@@ -8,11 +8,11 @@ import AssessmentStore    from "../stores/assessment";
 export default {
 
   loadAssessment(settings, srcData){
-    
+
     if(srcData){
       srcData = srcData.trim();
       if(srcData.length > 0){
-        Dispatcher.dispatch({ 
+        Dispatcher.dispatch({
           action: Constants.ASSESSMENT_LOADED,
           settings: settings,
           data: {
@@ -42,14 +42,14 @@ export default {
     Dispatcher.dispatch({action: Constants.QUESTION_SELECTED, index: index});
   },
 
-  checkAnswer(){
-    Dispatcher.dispatch({ action: Constants.ASSESSMENT_CHECK_ANSWER });
+  checkAnswer(qid){
+    Dispatcher.dispatch({ action: Constants.ASSESSMENT_CHECK_ANSWER, qid: qid });
   },
 
   selectConfidenceLevel(level, index){
     Dispatcher.dispatch({action: Constants.LEVEL_SELECTED, level: level, index: index});
   },
-  
+
   submitAssessment(identifier, assessmentId, questions, studentAnswers, settings, outcomes){
     Dispatcher.dispatch({action: Constants.ASSESSMENT_SUBMITTED});
     this.submitProgress();
@@ -107,7 +107,7 @@ export default {
   retakeAssessment(){
     Dispatcher.dispatch({action: Constants.RETAKE_ASSESSMENT})
   },
-  
+
   assessmentViewed(settings, assessment){
     var body = {
       assessment_result : {
@@ -149,5 +149,5 @@ export default {
     };
     Api.post(Constants.ASSESSMENT_VIEWED, '/api/item_results', body);
   }
-  
+
 };

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -37,9 +37,10 @@ export default class Item extends BaseComponent{
       if(AssessmentStore.hasAnsweredCurrent()){
         AssessmentActions.selectConfidenceLevel(val, currentIndex);
         if(that.props.currentIndex == that.props.questionCount - 1 && that.props.settings.assessmentKind.toUpperCase() == "FORMATIVE"){
-          that.submitAssessment();
+          // that.submitAssessment();
         } else {
-          AssessmentActions.nextQuestion();
+          // AssessmentActions.nextQuestion();
+
           that.clearShowMessage();
         }
       } else {
@@ -99,7 +100,7 @@ export default class Item extends BaseComponent{
   }
 
   getConfidenceLevels(level, styles){
-    if(level){
+    // if(level){
       var levelMessage = <div tabIndex="0" style={{marginBottom: "10px"}}><b>How sure are you of your answer? Click below to move forward.</b></div>;
       return    (<div className="confidence_wrapper" style={styles.confidenceWrapper}>
                   {levelMessage}
@@ -108,13 +109,14 @@ export default class Item extends BaseComponent{
                   <input type="button" style={{...styles.margin, ...styles.definitelyButton}} className="btn btn-check-answer" value="Very Sure" onClick={(e) => { this.confidenceLevelClicked(e, "Very Sure", this.props.currentIndex) }}/>
                 </div>
                 );
-    } /*else {
-      return <div className="lower_level"><input type="button" className="btn btn-check-answer" value="Check Answer" onClick={() => { AssessmentActions.checkAnswer()}}/></div>
-    }*/
+    // } else {
+    //   <div className="lower_level"><input type="button" className="btn btn-check-answer" value="Check Answer" onClick={() => { AssessmentActions.checkAnswer()}}/></div>
+    // }
   }
 
   getNavigationButtons(styles) {
-    if ( this.props.questionCount == 1 || (!this.context.theme.shouldShowNextPrevious && this.props.confidenceLevels)) {
+    // if ( this.props.questionCount == 1 || (!this.context.theme.shouldShowNextPrevious && this.props.confidenceLevels)) {
+    if ( this.props.questionCount == 1 ) {
       return "";
     }
 
@@ -291,9 +293,9 @@ export default class Item extends BaseComponent{
   }
 
   checkAnswerButton(styles) {
-    if ( !AssessmentStore.isPractice() ) {
-      return ""
-    }
+    // if ( !AssessmentStore.isPractice() ) {
+    //   return ""
+    // }
     var showingResult = this.props.answerMessage && !this.props.answerMessage.allowResubmit;
 
     return <div style={styles.checkAnswerButtonDiv}>

--- a/client/js/models/assessment.js
+++ b/client/js/models/assessment.js
@@ -94,6 +94,7 @@ export default class Assessment{
   }
 
   static checkAnswer(item, selectedAnswers){
+    console.log('how am i getting called?')
     var results;
     switch(item.question_type){
       case 'multiple_choice_question':


### PR DESCRIPTION
First commit makes it so confidence buttons, nav buttons, and check answer button render on a formative assessment question.  There will likely need to be logic tweaking here because I mostly just commented stuff out to make it work for me.

I'm getting hung up on where the `static checkAnswer()` method is getting called from in `client/js/models/assessment.js`.

Aside from my confusion about the above, the issue seems to be that in `client/js/stores/assessment.js`, the `_selectedAnswerIds` variable isn't being set, so it can't find the id that it needs:

```
function checkAnswer(){
  if(_selectedAnswerIds !== null){
    return Assessment.checkAnswer(_items[_itemIndex], _selectedAnswerIds);
  } else{ 
    return null;
  }
}
```