### PR TITLE
Remove swyk and summative quiz items associated with a given guid

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We can populate the database by running the following commands:
   $ APP_SUBDOMAIN=localhost bundle exec rake db:migrate
   $ APP_SUBDOMAIN=localhost bundle exec rake db:seed
   ```
-  
+
 ### 4. Install JavaScript Dependencies
 
 Make sure to have the correct version of Node running.
@@ -178,7 +178,7 @@ we use
 [Jasmine](https://github.com/jasmine/jasmine)
 and
 [Karma](https://github.com/karma-runner/karma)
-for running browser tests. 
+for running browser tests.
 To run tests against the JavaScript code,
 run `npm run test` from the `client/` directory in this project.
 
@@ -190,7 +190,15 @@ $ brew install chromedriver
 
 ## Deployment
 
-Assuming you are using
+Compile the frontend assets by running:
+
+  ```
+  $ RAILS_ENV=production bundle exec rake assets:precompile
+  $ RAILS_ENV=production bundle exec rake assets:webpack
+  ```
+
+Then,
+assuming you are using
 [AWS](https://aws.amazon.com/)
 for hosting and you have everything configured correctly,
 deployment is as simple as running `eb deploy` from the project root directory.

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -207,6 +207,7 @@ class Api::AssessmentsController < Api::ApiController
     raise ActiveRecord::RecordNotFound unless assessment
 
     assessment.remove_questions_for_guid!(params.require(:guid))
+    assessment.save!
 
     render :json => assessment
   end

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -2,7 +2,7 @@ require 'json2qti'
 require 'assessment_copier'
 
 class Api::AssessmentsController < Api::ApiController
-  
+
   respond_to :xml, :json
 
   before_action :ensure_context_admin, only:[:json_update, :review_show]
@@ -148,7 +148,7 @@ class Api::AssessmentsController < Api::ApiController
     @assessment.account = current_account
     @assessment.save!
     @assessment.assessment_settings.create(settings_params)
-    
+
     respond_with(:api, @assessment)
   end
 
@@ -159,7 +159,7 @@ class Api::AssessmentsController < Api::ApiController
     else
       @assessment.assessment_settings.create(settings_params)
     end
-    
+
     respond_with(:api, @assessment)
   end
 
@@ -202,6 +202,13 @@ class Api::AssessmentsController < Api::ApiController
     render :json => new_assessment
   end
 
+  def remove_questions_for_guid
+    assessment = Assessment.where(id: params[:assessment_id]).first
+    raise ActiveRecord::RecordNotFound unless assessment
+
+    assessment.remove_questions_for_guid!(guid: params.require(:guid))
+  end
+
   private
 
   # makes sure the JWT token allows admin scope for this LTI context id
@@ -222,7 +229,7 @@ class Api::AssessmentsController < Api::ApiController
                                          :src_url, :recommended_height, :keyword_list,
                                          :account_id, :kind)
     end
-  
+
   def settings_params
     settings = params.require(:assessment).permit(:allowed_attempts, :per_sec, :confidence_levels, :style, :enable_start)
     settings[:allowed_attempts] = settings[:allowed_attempts].to_i if settings[:allowed_attempts]

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -207,7 +207,6 @@ class Api::AssessmentsController < Api::ApiController
     raise ActiveRecord::RecordNotFound unless assessment
 
     assessment.remove_questions_for_guid!(params.require(:guid))
-    assessment.save!
 
     render :json => assessment
   end

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -207,6 +207,8 @@ class Api::AssessmentsController < Api::ApiController
     raise ActiveRecord::RecordNotFound unless assessment
 
     assessment.remove_questions_for_guid!(guid: params.require(:guid))
+
+    render :json => assessment
   end
 
   private

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -206,7 +206,8 @@ class Api::AssessmentsController < Api::ApiController
     assessment = Assessment.where(id: params[:assessment_id]).first
     raise ActiveRecord::RecordNotFound unless assessment
 
-    assessment.remove_questions_for_guid!(guid: params.require(:guid))
+    assessment.remove_questions_for_guid!(params.require(:guid))
+    assessment.save!
 
     render :json => assessment
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -92,6 +92,16 @@ class Assessment < ActiveRecord::Base
 
   end
 
+  def remove_questions_for_guid!(guid)
+    if self.summative?
+      new_assessment_xml = AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.no_answer_xml, guid)
+      self.current_assessment_xml.no_answer_xml = new_assessment_xml
+    else
+      new_assessment_xml = AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.xml, guid)
+      self.current_assessment_xml.xml = new_assessment_xml
+    end
+  end
+
   def parsed_xml(xml = nil)
     @parsed_xml ||= AssessmentParser.parse(xml).first if xml.present?
     @parsed_xml

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -94,7 +94,7 @@ class Assessment < ActiveRecord::Base
 
   def remove_questions_for_guid!(guid)
     if (self.current_assessment_xml)
-      AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.xml, guid)
+      self.xml_file = AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.xml, guid)
     end
   end
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -93,12 +93,8 @@ class Assessment < ActiveRecord::Base
   end
 
   def remove_questions_for_guid!(guid)
-    if self.summative?
-      new_assessment_xml = AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.no_answer_xml, guid)
-      self.current_assessment_xml.no_answer_xml = new_assessment_xml
-    else
-      new_assessment_xml = AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.xml, guid)
-      self.current_assessment_xml.xml = new_assessment_xml
+    if (self.current_assessment_xml)
+      AssessmentXml.remove_questions_for_guid(self.current_assessment_xml.xml, guid)
     end
   end
 

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -46,4 +46,45 @@ class AssessmentXml < ActiveRecord::Base
     node.to_xml
   end
 
+  def self.remove_questions_for_guid(xml, guid)
+    node = Nokogiri::XML(xml)
+
+    # remove items with specified outcome guid
+    if node.css('section section').any?
+      node.css('section section').each do |section|
+        if section.css('item')
+          section.css('item').each do |item|
+            item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
+              if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
+                item.remove
+              end
+            end
+          end
+        end
+      end
+    else
+      node.css('section').each do |section|
+        if section.css('item')
+          section.css('item').each do |item|
+            item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
+              if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
+                item.remove
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # after removing items, remove section if section is now empty
+    if node.css('section section').any?
+      node.css('section section').each do |section|
+        unless section.css('item').any?
+          section.remove
+        end
+      end
+    end
+
+    node.to_xml
+  end
 end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -79,6 +79,7 @@ class AssessmentXml < ActiveRecord::Base
     node.to_xml
   end
 
+
   # Remove all items from a given section for a given outcome guid
   #
   # Inside a section, we expect an xml structure like...

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -79,13 +79,30 @@ class AssessmentXml < ActiveRecord::Base
     node.to_xml
   end
 
+  # Remove all items from a given section for a given outcome guid
+  #
+  # Inside a section, we expect an xml structure like...
+  # <item>
+  #   <itemmetadata>
+  #     <qtimetadata>
+  #       ...
+  #       <qtimetadatafield>
+  #         <fieldlabel>outcome_guid</fieldlabel>
+  #         <fieldentry>12345678-cd69-46f6-807a-asdfghjkl666</fieldentry>
+  #       </qtimetadatafield>
+  #       ...
+  #     </qtimetadata>
+  #   </itemmetadata>
+  # </item>
   def self.remove_items_from_section(section, guid)
-    if section.css('item')
+    if section.css('item').any?
       section.css('item').each do |item|
-        item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
-          if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
-            # remove items with specified outcome guid
-            item.remove
+        if item.css('itemmetadata qtimetadata qtimetadatafield').any?
+          item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
+            if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
+              # remove item with given outcome guid
+              item.remove
+            end
           end
         end
       end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -102,7 +102,6 @@ class AssessmentXml < ActiveRecord::Base
             if metafield.css('fieldentry').children.to_s == guid.to_s
               # remove item with given outcome guid
               item.remove
-              return
             end
           end
         end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -79,7 +79,6 @@ class AssessmentXml < ActiveRecord::Base
     node.to_xml
   end
 
-
   # Remove all items from a given section for a given outcome guid
   #
   # Inside a section, we expect an xml structure like...
@@ -100,9 +99,10 @@ class AssessmentXml < ActiveRecord::Base
       section.css('item').each do |item|
         if item.css('itemmetadata qtimetadata qtimetadatafield').any?
           item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
-            if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
+            if metafield.css('fieldentry').children.to_s == guid.to_s
               # remove item with given outcome guid
               item.remove
+              return
             end
           end
         end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -49,30 +49,21 @@ class AssessmentXml < ActiveRecord::Base
   def self.remove_questions_for_guid(xml, guid)
     node = Nokogiri::XML(xml)
 
-    # remove items with specified outcome guid
+    # We expect an xml structure like ...
+    # <section>
+    #     <section><item /></section>
+    # </section>
     if node.css('section section').any?
       node.css('section section').each do |section|
-        if section.css('item')
-          section.css('item').each do |item|
-            item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
-              if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
-                item.remove
-              end
-            end
-          end
-        end
+        remove_items_from_section(section, guid)
       end
+    # But sometimes the xml structure can be just one "section" deep ...
+    # <section>
+    #     <item />
+    # </section>
     else
       node.css('section').each do |section|
-        if section.css('item')
-          section.css('item').each do |item|
-            item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
-              if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
-                item.remove
-              end
-            end
-          end
-        end
+        remove_items_from_section(section, guid)
       end
     end
 
@@ -86,5 +77,18 @@ class AssessmentXml < ActiveRecord::Base
     end
 
     node.to_xml
+  end
+
+  def self.remove_items_from_section(section, guid)
+    if section.css('item')
+      section.css('item').each do |item|
+        item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
+          if metafield.css('fieldlabel').children.text == 'outcome_guid' && metafield.css('fieldentry').children.text == guid
+            # remove items with specified outcome guid
+            item.remove
+          end
+        end
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
       get 'results/:result_id', to: 'assessment_results#show'
       put '/edit', to: 'assessments#json_update'
       post '/copy', to: 'assessments#copy', as: 'assessments_copy'
-      post '/remove-questions-for-guid', to: 'assessments#remove_questions_for_guid', as: 'assessments_remove_questions_for_guid'
+      post '/remove-questions-for-guid', to: 'assessments#remove_questions_for_guid'
     end
     resources :assessment_results do
       post 'send', to: 'assessment_results#send_result_to_analytics'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
       get 'results/:result_id', to: 'assessment_results#show'
       put '/edit', to: 'assessments#json_update'
       post '/copy', to: 'assessments#copy', as: 'assessments_copy'
+      post '/remove-questions-for-guid', to: 'assessments#remove_questions_for_guid', as: 'assessments_remove_questions_for_guid'
     end
     resources :assessment_results do
       post 'send', to: 'assessment_results#send_result_to_analytics'

--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -2,7 +2,7 @@ require 'pp'
 
 desc 'compile bundles using webpack'
 task "assets:webpack" do
-  cmd    = 'cd client && webpack --config webpack.release.js --progress --profile --colors --json'
+  cmd    = 'cd client && node_modules/webpack/bin/webpack.js --config webpack.release.js --progress --profile --colors --json'
   output = `#{cmd}`
   stats  = JSON.parse output
 

--- a/spec/controllers/api/assessments_controller_spec.rb
+++ b/spec/controllers/api/assessments_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::AssessmentsController, type: :controller do
     @account.save!
     @user = FactoryGirl.create(:user, account: @account)
     @user.confirm!
-    
+
     @admin = CreateAdminService.new.call
     @admin.make_account_admin({account_id: @account.id})
 
@@ -161,7 +161,7 @@ RSpec.describe Api::AssessmentsController, type: :controller do
         @payload = { :user_id => @admin.id, AuthToken::ADMIN_SCOPES => ['extcontext'], 'lti_launch_id' => @lti_launch.id }
         @edit_token = AuthToken.issue_token(@payload)
         @params = {format: :xml, id: @assessment.id, for_review: 1}
-        
+
         request.headers['Authorization'] = @edit_token
        end
 
@@ -321,7 +321,7 @@ RSpec.describe Api::AssessmentsController, type: :controller do
 
     it "creates an assessment" do
       post :create, assessment: @params, format: :json
-      
+
       expect(response).to have_http_status(201)
       a = Assessment.last
       expect(a.title).to eq @params[:title]
@@ -374,7 +374,7 @@ RSpec.describe Api::AssessmentsController, type: :controller do
       expect(assessment.xml_without_answers).not_to include("conditionvar")
       expect(response).to have_http_status(:success)
     end
-    
+
     it "should create assessment settings" do
       @params = {}
       @params[:title] = 'Test'
@@ -395,7 +395,7 @@ RSpec.describe Api::AssessmentsController, type: :controller do
       expect( settings.allowed_attempts ).to eq 2
       expect( settings.mode ).to eq @assessment.kind
     end
-    
+
     it "should update assessment settings" do
       orig_settings = @assessment.assessment_settings.create(mode: 'summative')
       @params = {}

--- a/spec/fixtures/summative_quiz_example.xml
+++ b/spec/fixtures/summative_quiz_example.xml
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Plant Reproduction" ident="i3c1fc8e493c74d7a91e21219ca6be2b5_summative">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>qmd_timelimit</fieldlabel>
+        <fieldentry/>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry/>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <section title="Lorem ipsum dolor sit amet, consectetur adipiscing elit." ident="ida4f472d73182bed8b2a75517ea689d5">
+        <selection_ordering>
+          <selection>
+            <sourcebank_ref/>
+            <selection_number>1</selection_number>
+            <selection_extension>
+              <points_per_item>1</points_per_item>
+            </selection_extension>
+          </selection>
+        </selection_ordering>
+        <item title="Lorem ipsum dolor sit amet, consectetur adipiscing elit." ident="i30a2fc9e93004b12fce13f9e7d243df7">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">The ________ develops from the the black hole.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50">
+                  <material>
+                    <mattext texttype="text/html">gametophyte</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i99733d9ad0b8abfc9844b7cd48b4531c">
+                  <material>
+                    <mattext texttype="text/html">sporangium</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="icde64c0315f2faa3b2695a9afd760fbd">
+                  <material>
+                    <mattext texttype="text/html">sporophyte</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i99733d9ad0b8abfc9844b7cd48b4531c_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="icde64c0315f2faa3b2695a9afd760fbd_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The game does not stop for the diploid.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i99733d9ad0b8abfc9844b7cd48b4531c_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The game does not develop from the nothing.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="icde64c0315f2faa3b2695a9afd760fbd_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. The dippidy zebra, which is a product of horse meat by fusion of the gametes.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+        <item title="Lorem ipsum dolor sit amet, consectetur adipiscing elit." ident="iec6328b26c2764d54db3aa029b313d0e">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">The gametophyte produces ________ by ________.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="ib15432172bdd80dd3a8094d070b19edc">
+                  <material>
+                    <mattext texttype="text/html">diploid zygote; cloning</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i7295bcaea7e5f54b36d84f8bf791f495">
+                  <material>
+                    <mattext texttype="text/html">triploid megaspores; fusion</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i4aa360cb177534768007a5fe75718715">
+                  <material>
+                    <mattext texttype="text/html">haploid gametes; mitosis</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">ib15432172bdd80dd3a8094d070b19edc</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="ib15432172bdd80dd3a8094d070b19edc_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i7295bcaea7e5f54b36d84f8bf791f495</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i7295bcaea7e5f54b36d84f8bf791f495_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i4aa360cb177534768007a5fe75718715</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i4aa360cb177534768007a5fe75718715_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">ib15432172bdd80dd3a8094d070b19edc</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i7295bcaea7e5f54b36d84f8bf791f495</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i4aa360cb177534768007a5fe75718715</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="ib15432172bdd80dd3a8094d070b19edc_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. Some plants scream constantly.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i7295bcaea7e5f54b36d84f8bf791f495_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. Some plants scream like goats who scream like humans.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i4aa360cb177534768007a5fe75718715_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. That...that is correct. Well done.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+        <item title="Lorem ipsum dolor sit amet, consectetur adipiscing elit." ident="icc9c2da8eb907d4d66d5f306383d82c7">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">In ________ planets.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="i304fd2cb82de259d06aa90af3525a13f">
+                  <material>
+                    <mattext texttype="text/html">nonvastibularized</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i3d8b8eae44ed316fef1c570fbeafa87a">
+                  <material>
+                    <mattext texttype="text/html">both vascular and blastometric</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i8e40978518318277636494b42b85d1c1">
+                  <material>
+                    <mattext texttype="text/html">hyperbolic</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i304fd2cb82de259d06aa90af3525a13f</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i304fd2cb82de259d06aa90af3525a13f_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i3d8b8eae44ed316fef1c570fbeafa87a</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i3d8b8eae44ed316fef1c570fbeafa87a_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i8e40978518318277636494b42b85d1c1</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i8e40978518318277636494b42b85d1c1_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i304fd2cb82de259d06aa90af3525a13f</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i3d8b8eae44ed316fef1c570fbeafa87a</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i8e40978518318277636494b42b85d1c1</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="i304fd2cb82de259d06aa90af3525a13f_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i3d8b8eae44ed316fef1c570fbeafa87a_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i8e40978518318277636494b42b85d1c1_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. The ganglia is dominant in “higher” homophones.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>

--- a/spec/fixtures/swyk_quiz_example.xml
+++ b/spec/fixtures/swyk_quiz_example.xml
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Plant Reproduction" ident="i3c1fc8e493c74d7a91e21219ca6be2b5_swyk">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>qmd_timelimit</fieldlabel>
+        <fieldentry/>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry/>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <section title="Mauris sagittis sagittis urna, quis rutrum leo pellentesque in." ident="ida4f472d73182bed8b2a75517ea689d5">
+        <selection_ordering>
+          <selection>
+            <sourcebank_ref/>
+            <selection_number>1</selection_number>
+            <selection_extension>
+              <points_per_item>1</points_per_item>
+            </selection_extension>
+          </selection>
+        </selection_ordering>
+        <item title="Mauris sagittis sagittis urna, quis rutrum leo pellentesque in." ident="i3c93b88d2102d5e9d7182583c2a20b1d">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">The fungus develops from the ________.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="iffd0a48f651ce47695c9982aa8605063">
+                  <material>
+                    <mattext texttype="text/html">Lorem ipsum dolor sit amet</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i4f506948dbc3742d688cc464b2d84992">
+                  <material>
+                    <mattext texttype="text/html">Lorem ipsum dolor sit amet</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i3d5ae523388f922a6c358e55923a2af2">
+                  <material>
+                    <mattext texttype="text/html">diploid zygote</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">iffd0a48f651ce47695c9982aa8605063</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="iffd0a48f651ce47695c9982aa8605063_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i4f506948dbc3742d688cc464b2d84992</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i4f506948dbc3742d688cc464b2d84992_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i3d5ae523388f922a6c358e55923a2af2</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i3d5ae523388f922a6c358e55923a2af2_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">iffd0a48f651ce47695c9982aa8605063</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i4f506948dbc3742d688cc464b2d84992</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i3d5ae523388f922a6c358e55923a2af2</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="iffd0a48f651ce47695c9982aa8605063_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The Lorem ipsum dolor sit amet.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i4f506948dbc3742d688cc464b2d84992_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The fox does not develop from a Lorem ipsum dolor sit amet.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i3d5ae523388f922a6c358e55923a2af2_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. The goat develops from the Lorem ipsum dolor sit amet, which is produced by fusion of the Lorem ipsum dolor sit amet.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+        <item title="Mauris sagittis sagittis urna, quis rutrum leo pellentesque in." ident="i0a9df7af9f831b75f874028bd0183307">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">The ________ produces Lorem ipsum dolor sit amet by mitochondria.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="icde64c0315f2faa3b2695a9afd760fbd">
+                  <material>
+                    <mattext texttype="text/html">spores</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i99733d9ad0b8abfc9844b7cd48b4531c">
+                  <material>
+                    <mattext texttype="text/html">bees</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50">
+                  <material>
+                    <mattext texttype="text/html">games</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="icde64c0315f2faa3b2695a9afd760fbd_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i99733d9ad0b8abfc9844b7cd48b4531c_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="icde64c0315f2faa3b2695a9afd760fbd_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The spores does not produce Lorem ipsum dolor sit amet by mitosis.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i99733d9ad0b8abfc9844b7cd48b4531c_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The bees does not produce Lorem ipsum dolor sit amet by mitosis.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. The happy family produces male and female Lorem ipsum dolor sit amet in distinct structures.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+        <item title="Mauris sagittis sagittis urna, quis rutrum leo pellentesque in." ident="i67c1ea1e4fef97dead77e24105918ecd">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_choice_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>f71c5ce2-46b7-4cce-9531-1680d42faf1b</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_guid</fieldlabel>
+                <fieldentry>9d5b9603-f8c2-4614-bf0b-090b71a65c13</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_short_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>skill_long_title</fieldlabel>
+                <fieldentry>Mauris sagittis sagittis urna, quis rutrum leo pellentesque in.</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material>
+              <mattext texttype="text/html">In muscular plants, the ________ is the dominant phase of the bicycle.</mattext>
+            </material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="i99733d9ad0b8abfc9844b7cd48b4531c">
+                  <material>
+                    <mattext texttype="text/html">sporangium</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50">
+                  <material>
+                    <mattext texttype="text/html">gametophyte</mattext>
+                  </material>
+                </response_label>
+                <response_label ident="icde64c0315f2faa3b2695a9afd760fbd">
+                  <material>
+                    <mattext texttype="text/html">sporophyte</mattext>
+                  </material>
+                </response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes>
+              <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+            </outcomes>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i99733d9ad0b8abfc9844b7cd48b4531c_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb"/>
+            </respcondition>
+            <respcondition continue="Yes">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <displayfeedback feedbacktype="Response" linkrefid="icde64c0315f2faa3b2695a9afd760fbd_fb"/>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i99733d9ad0b8abfc9844b7cd48b4531c</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">i93e6b7e0fb9fbbed46fee5b4b01f3a50</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">0</setvar>
+            </respcondition>
+            <respcondition continue="No">
+              <conditionvar>
+                <varequal respident="response1">icde64c0315f2faa3b2695a9afd760fbd</varequal>
+              </conditionvar>
+              <setvar varname="SCORE" action="Set">100</setvar>
+            </respcondition>
+          </resprocessing>
+          <itemfeedback ident="i99733d9ad0b8abfc9844b7cd48b4531c_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. All plants have a sporangium but it is never a dominant phase of the lifecycle.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="i93e6b7e0fb9fbbed46fee5b4b01f3a50_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Incorrect. The haploid organism is the dominant phase of a nonvascular plants life cycle.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="icde64c0315f2faa3b2695a9afd760fbd_fb">
+            <flow_mat>
+              <material>
+                <mattext texttype="text/plain">Correct. The sporophyte is dominant in “higher” vascular plants.</mattext>
+              </material>
+            </flow_mat>
+          </itemfeedback>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -121,30 +121,4 @@ describe Assessment do
       expect(Assessment.tagged_with(keyword).first).to eq(@assessment)
     end
   end
-
-  context 'removing questions for a guid' do
-    before do
-      @swyk_assessment = Assessment.create!(title: 'testing', kind: 'show_what_you_know', xml_file: File.read(File.join(__dir__, '../fixtures/swyk_quiz_example.xml')) )
-      @summative_assessment = Assessment.create!(title: 'testing', kind: 'summative', xml_file: File.read(File.join(__dir__, '../fixtures/summative_quiz_example.xml')) )
-      @guid_to_delete = 'f71c5ce2-46b7-4cce-9531-1680d42faf1b'
-    end
-
-    it 'should remove the questions in the xml with answers' do
-      @new_swyk_assessment = @swyk_assessment.remove_questions_for_guid!(@guid_to_delete)
-      expect(@new_swyk_assessment).to_not match(@guid_to_delete)
-    end
-
-    it 'should remove the questions in the xml without answers' do
-      @new_summative_assessment = @summative_assessment.remove_questions_for_guid!(@guid_to_delete)
-      expect(@new_summative_assessment).to_not match(@guid_to_delete)
-    end
-
-    it 'removes the section if its empty' do
-      @swyk_node = Nokogiri::XML(@new_swyk_assessment_xml)
-      @summative_node = Nokogiri::XML(@new_swyk_assessment_xml)
-
-      expect(@swyk_node.css('section section').count).to eq(0)
-      expect(@summative_node.css('section section').count).to eq(0)
-    end
-  end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -122,4 +122,29 @@ describe Assessment do
     end
   end
 
+  context 'removing questions for a guid' do
+    before do
+      @swyk_assessment = Assessment.create!(title: 'testing', kind: 'show_what_you_know', xml_file: File.read(File.join(__dir__, '../fixtures/swyk_quiz_example.xml')) )
+      @summative_assessment = Assessment.create!(title: 'testing', kind: 'summative', xml_file: File.read(File.join(__dir__, '../fixtures/summative_quiz_example.xml')) )
+      @guid_to_delete = 'f71c5ce2-46b7-4cce-9531-1680d42faf1b'
+    end
+
+    it 'should remove the questions in the xml with answers' do
+      @new_swyk_assessment = @swyk_assessment.remove_questions_for_guid!(@guid_to_delete)
+      expect(@new_swyk_assessment).to_not match(@guid_to_delete)
+    end
+
+    it 'should remove the questions in the xml without answers' do
+      @new_summative_assessment = @summative_assessment.remove_questions_for_guid!(@guid_to_delete)
+      expect(@new_summative_assessment).to_not match(@guid_to_delete)
+    end
+
+    it 'removes the section if its empty' do
+      @swyk_node = Nokogiri::XML(@new_swyk_assessment_xml)
+      @summative_node = Nokogiri::XML(@new_swyk_assessment_xml)
+
+      expect(@swyk_node.css('section section').count).to eq(0)
+      expect(@summative_node.css('section section').count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Overview

This feature adds an endpoint that allows for "summative" and "show what you know" questions to be deleted that are associated to a given GUID.