### PR TITLE
Move questions from one assessment to another

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pickle-email-*.html
 secrets.js
 *_web_pack_bundle.js
 .idea/
+*.iml
 .env
 .DS_Store
 

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -212,6 +212,19 @@ class Api::AssessmentsController < Api::ApiController
     render :json => assessment
   end
 
+  def move_questions_for_guid
+    source_assessment = Assessment.where(id: params[:source_assessment_id]).first
+    raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
+    destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
+    raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment
+
+    Assessment.move_questions_for_guid!(source_assessment, destination_assessment, params[:guid])
+    source_assessment.save!
+    destination_assessment.save!
+
+    render :json => destination_assessment
+  end
+
   private
 
   # makes sure the JWT token allows admin scope for this LTI context id

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -187,4 +187,12 @@ class Assessment < ActiveRecord::Base
     end
   end
 
+  def self.move_questions_for_guid!(source_assessment, destination_assessment, guid)
+    if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(self.current_assessment_xml.xml, guid)
+      source_assessment.xml_file = updated_source_xml
+      destination_assessment.xml_file = updated_destination_xml
+    end
+  end
 end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -159,7 +159,7 @@ class AssessmentXml < ActiveRecord::Base
     if source_section.to_s =~ /#{guid}/ # is the guid present in this section's xml?
       dest_root_section = root_section(destination_doc)
       if root_section_contains_child_sections?(destination_doc)
-        destination_section = create_mirror_section!(source_doc, source_section, dest_root_section)
+        destination_section = create_mirror_section!(source_doc, source_section, dest_root_section, guid)
       else
         destination_section = dest_root_section
       end
@@ -171,10 +171,14 @@ class AssessmentXml < ActiveRecord::Base
     doc.css('section section').any?
   end
 
-  def self.create_mirror_section!(source_document, source_section, destination_root_section)
+  def self.create_mirror_section!(source_document, source_section, destination_root_section, guid)
     mirror_section = Nokogiri::XML::Node.new "section", source_document
     if source_section['ident']
-      mirror_section['ident'] = source_section['ident']
+      if source_section['ident'] == "root_section"
+        mirror_section['ident'] = "copy_for_#{guid}"
+      else
+        mirror_section['ident'] = source_section['ident']
+      end
     end
     if source_section['title']
       mirror_section['title'] = source_section['title']

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -109,25 +109,6 @@ class AssessmentXml < ActiveRecord::Base
     end
   end
 
-  def self.move_questions_for_guid(source_xml, destination_xml, guid)
-    node = Nokogiri::XML(source_xml)
-
-    if self.root_section_contains_child_sections?(node)
-      node.css('section section').each do |section|
-        remove_items_from_section(section, guid)
-      end
-    else
-      node.css('section').each do |section|
-        remove_items_from_section(section, guid)
-      end
-    end
-
-    # after moving items, remove section if section is now empty
-    clear_empty_child_sections!(node)
-
-    node.to_xml
-  end
-
   def self.clear_empty_child_sections!(doc)
     if root_section_contains_child_sections?(doc)
       doc.css('section section').each do |section|
@@ -142,7 +123,10 @@ class AssessmentXml < ActiveRecord::Base
     doc.css('assessment > section').first
   end
 
-  def self.move_questions_for_guid!(source_doc, destination_doc, guid)
+  def self.move_questions_for_guid(source_xml_string, destination_xml_string, guid)
+    source_doc = Nokogiri::XML(source_xml_string)
+    destination_doc = Nokogiri::XML(destination_xml_string)
+
     destination_section = nil
     if root_section_contains_child_sections?(source_doc)
       source_doc.css('section section').each do |source_section|
@@ -153,6 +137,7 @@ class AssessmentXml < ActiveRecord::Base
       source_section = root_section(source_doc)
       move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)
     end
+    return source_doc.to_xml, destination_doc.to_xml
   end
 
   def self.move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -148,8 +148,8 @@ class AssessmentXml < ActiveRecord::Base
     doc.css('section section').any?
   end
 
-  def self.create_mirror_section!(source_section, destination_root_section)
-    mirror_section = Nokogiri::XML::Node.new "section"
+  def self.create_mirror_section!(source_document, source_section, destination_root_section)
+    mirror_section = Nokogiri::XML::Node.new "section", source_document
     if source_section['ident']
       mirror_section['ident'] = source_section['ident']
     end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1072,9 +1072,9 @@ describe AssessmentXml do
     end
   end
 
-  context "AssessmentXml.move_questions_for_guid!" do
+  context "AssessmentXml.move_questions_for_guid" do
     it "should move items for every section which has an item with a matching guid" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1200,7 +1200,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1234,13 +1234,14 @@ describe AssessmentXml do
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[1]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[2]).length).to eq 1
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
@@ -1248,7 +1249,7 @@ describe AssessmentXml do
     end
 
     it "should clear out sections if a child section has all items removed" do
-source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1328,7 +1329,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1362,18 +1363,19 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
     end
 
     it "should move items from root section if no child sections exist" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1449,7 +1451,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1483,18 +1485,19 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
     end
 
     it "should never remove root section, even if no items or sections are left in it" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1548,7 +1551,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1582,11 +1585,12 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(source_root).not_to be_nil
       expect(retrieve_children_elements(source_root).length).to eq 0
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1,4 +1,9 @@
 require 'rails_helper'
+require 'support/nokogiri_helpers'
+
+RSpec.configure do |config|
+  config.include NokogiriHelpers
+end
 
 describe AssessmentXml do
   before do
@@ -228,17 +233,17 @@ describe AssessmentXml do
     end
 
     it "should move the item from the source to the destination, if the guid is found in the item in the source" do
-      original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
-      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 2
-      expect(@destination_section.children.select { |child| child.element? }.length).to eq 4
+      expect(retrieve_children_elements(@source_section).length).to eq 0
+      expect(retrieve_children_elements(@source_section.parent).length).to eq 3
+      expect(retrieve_children_elements(@destination_section).length).to eq 4
     end
 
     it "should leave the two XMLs unchanged if guid is not found in the source" do
       original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, 'adfb2853-598d-48f7-8206-50edaac3a16c')
-      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 3
-      expect(@destination_section.children.select { |child| child.element? }.length).to eq 3
+      expect(retrieve_children_elements(original_source_parent).length).to eq 3
+      expect(retrieve_children_elements(@destination_section).length).to eq 3
     end
   end
 

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -57,4 +57,189 @@ describe AssessmentXml do
 
   end
 
+  context "AssessmentXml.move_items_from_section" do
+    before(:each) do
+      @source_xml = Nokogiri::HTML::DocumentFragment.parse <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="The Expenditure Multiplier" ident="2902">
+        <item title="" ident="1737">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      @destination_xml = Nokogiri::HTML::DocumentFragment.parse <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Defining Economic Growth" ident="8139">
+        <item title="" ident="9436">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>a9ba38f3-acc9-42bd-9567-9442d87819d7</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Defining Economic Growth</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Define economic growth</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Sources of Economic Growth" ident="3150">
+        <item title="" ident="7876">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>3f99debb-6b1d-4544-a147-357df2a0e997</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Sources of Economic Growth</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Identify the sources of economic growth</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      @source_section = @source_xml.css("section[ident='170']").first
+      @destination_section = @destination_xml.css("section[ident='root_section']").first
+    end
+
+    it "should move the item from the source to the destination, if the guid is found in the item in the source" do
+      original_source_parent = @source_section.parent
+      AssessmentXml.move_items(@source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
+      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 2
+      expect(@destination_section.children.select { |child| child.element? }.length).to eq 4
+    end
+
+    it "should leave the two XMLs unchanged if guid is not found in the source" do
+      original_source_parent = @source_section.parent
+      AssessmentXml.move_items(@source_section, @destination_section, 'adfb2853-598d-48f7-8206-50edaac3a16c')
+      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 3
+      expect(@destination_section.children.select { |child| child.element? }.length).to eq 3
+    end
+  end
+
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -631,7 +631,7 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       expect(retrieve_children_elements(source_section).length).to be 1
       expect(retrieve_children_elements(source_section.parent).length).to be 1
       expect(retrieve_children_elements(destination_section).length).to be 2
@@ -640,7 +640,7 @@ describe AssessmentXml do
     end
 
     it "will add ident and title to mirror section element if source element contains them" do
-source_xml = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -711,12 +711,88 @@ source_xml = Nokogiri::XML <<-EOSOURCEXML
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       expect(destination_section.children.last['ident']).to eq "170"
       expect(destination_section.children.last['title']).to eq "Liquidity Trap"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "170"
       expect(mirror_section['title']).to eq "Liquidity Trap"
+    end
+
+    it "will give mirror section a new name if copying from source root section" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='root_section']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      expect(destination_section.children.last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
     end
   end
 
@@ -997,5 +1073,523 @@ source_xml = Nokogiri::XML <<-EOSOURCEXML
   end
 
   context "AssessmentXml.move_questions_for_guid!" do
+    it "should move items for every section which has an item with a matching guid" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="The Expenditure Multiplier" ident="2902">
+        <item title="" ident="1737">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 3
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[1]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[2]).length).to eq 1
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 3
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2]).length).to eq 1
+    end
+
+    it "should clear out sections if a child section has all items removed" do
+source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
+
+    it "should move items from root section if no child sections exist" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="5326">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Crowding Out</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 1
+      expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
+
+    it "should never remove root section, even if no items or sections are left in it" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(source_root).not_to be_nil
+      expect(retrieve_children_elements(source_root).length).to eq 0
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -64,7 +64,7 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_items_from_section" do
     before(:each) do
-      @source_xml = Nokogiri::HTML::DocumentFragment.parse <<-EOSOURCEXML
+      @source_xml = Nokogiri::XML <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -146,7 +146,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      @destination_xml = Nokogiri::HTML::DocumentFragment.parse <<-EODESTXML
+      @destination_xml = Nokogiri::XML <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -245,6 +245,248 @@ describe AssessmentXml do
       expect(retrieve_children_elements(original_source_parent).length).to eq 3
       expect(retrieve_children_elements(@destination_section).length).to eq 3
     end
+
+    it "will remove only those items in a section which match the guid" do
+      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+            <item title="" ident="5326">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Crowding Out</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+          <section title="The Expenditure Multiplier" ident="2902">
+            <item title="" ident="1737">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>The Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOSOURCEXML
+
+      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
+
+      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
+      expect(retrieve_children_elements(two_items_source_section).length).to eq 1
+      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
+      expect(retrieve_children_elements(@destination_section).length).to eq 4
+    end
+
+    it "will remove all of the items from the source section if they match on guid" do
+      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+            <item title="" ident="5326">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Crowding Out</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+          <section title="The Expenditure Multiplier" ident="2902">
+            <item title="" ident="1737">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>The Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOSOURCEXML
+
+      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
+      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
+      expect(retrieve_children_elements(two_items_source_section).length).to eq 0
+      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
+      expect(retrieve_children_elements(@destination_section).length).to eq 5
+    end
   end
 
+  context "AssessmentXml.clear_empty_child_sections!" do
+    it "will clear sections which are empty" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      section = xml.css("section[ident='root_section']").first
+      
+      AssessmentXml.clear_empty_child_sections!(xml)
+      expect(retrieve_children_elements(section).length).to be 0
+    end
+
+    it "will not clear sections which have items in them" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      section = xml.css("section[ident='root_section']").first
+
+      AssessmentXml.clear_empty_child_sections!(xml)
+      expect(retrieve_children_elements(section).length).to be 1
+    end
+  end
+
+  context "AssessmentXml.root_section_contains_child_sections?" do
+  end
+
+  context "AssessmentXml.create_mirror_section!" do
+  end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -485,6 +485,77 @@ describe AssessmentXml do
   end
 
   context "AssessmentXml.root_section_contains_child_sections?" do
+    it "will return true if the root section has child sections" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_truthy
+    end
+
+    it "will return false if the root section does not have child sections" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <item title="" ident="7773">
+            <itemmetadata>
+              <qtimetadata>
+                <qtimetadatafield>
+                  <fieldlabel>question_type</fieldlabel>
+                  <fieldentry>multiple_answers_question</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_guid</fieldlabel>
+                  <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_short_title</fieldlabel>
+                  <fieldentry>Liquidity Trap</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_long_title</fieldlabel>
+                  <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                </qtimetadatafield>
+              </qtimetadata>
+            </itemmetadata>
+          </item>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_falsy
+    end
   end
 
   context "AssessmentXml.create_mirror_section!" do

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -559,5 +559,159 @@ describe AssessmentXml do
   end
 
   context "AssessmentXml.create_mirror_section!" do
+    it "will create a mirror section" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      expect(retrieve_children_elements(source_section).length).to be 1
+      expect(retrieve_children_elements(source_section.parent).length).to be 1
+      expect(retrieve_children_elements(destination_section).length).to be 2
+    end
+
+    it "will add ident and title to mirror section element if source element contains them" do
+source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      expect(destination_section.children.last['ident']).to eq "170"
+      expect(destination_section.children.last['title']).to eq "Liquidity Trap"
+    end
   end
 end

--- a/spec/support/nokogiri_helpers.rb
+++ b/spec/support/nokogiri_helpers.rb
@@ -1,0 +1,5 @@
+module NokogiriHelpers
+  def retrieve_children_elements(node)
+    node.children.select { |child| child.element? }
+  end
+end


### PR DESCRIPTION
* Create an endpoint that takes in ID of source assessment, ID of target assessment, and outcome guid associated with questions to move
* Move those questions from source assessment QTI XML to target assessment QTI XML
* save both the source and the destination and render back the updated destination assessment.