### PR TITLE
put moved quiz items into the correct order

### DIFF
--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -213,7 +213,7 @@ class Api::AssessmentsController < Api::ApiController
   end
 
   def move_questions_for_guid
-    source_assessment = Assessment.where(id: params[:id]).first
+    source_assessment = Assessment.where(id: params[:assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -1,6 +1,5 @@
 require 'json2qti'
 require 'assessment_copier'
-require 'pp'
 
 class Api::AssessmentsController < Api::ApiController
 
@@ -218,11 +217,6 @@ class Api::AssessmentsController < Api::ApiController
     raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment
-
-    puts "********** SOURCE ASSESSMENT"
-    pp source_assessment
-    puts "********** DESTINATION ASSESSMENT"
-    pp destination_assessment
 
     Assessment.move_questions_for_guid!(source_assessment, destination_assessment, params[:guid])
     source_assessment.save!

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -213,7 +213,7 @@ class Api::AssessmentsController < Api::ApiController
   end
 
   def move_questions_for_guid
-    source_assessment = Assessment.where(id: params[:source_assessment_id]).first
+    source_assessment = Assessment.where(id: params[:id]).first
     raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -218,7 +218,7 @@ class Api::AssessmentsController < Api::ApiController
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment
 
-    Assessment.move_questions_for_guid!(source_assessment, destination_assessment, params[:guid])
+    Assessment.move_questions_for_guid!(source_assessment, destination_assessment, params[:guid], params[:after])
     source_assessment.save!
     destination_assessment.save!
 

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -1,5 +1,6 @@
 require 'json2qti'
 require 'assessment_copier'
+require 'pp'
 
 class Api::AssessmentsController < Api::ApiController
 
@@ -217,6 +218,11 @@ class Api::AssessmentsController < Api::ApiController
     raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment
+
+    puts "********** SOURCE ASSESSMENT"
+    pp source_assessment
+    puts "********** DESTINATION ASSESSMENT"
+    pp destination_assessment
 
     Assessment.move_questions_for_guid!(source_assessment, destination_assessment, params[:guid])
     source_assessment.save!

--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -213,7 +213,7 @@ class Api::AssessmentsController < Api::ApiController
   end
 
   def move_questions_for_guid
-    source_assessment = Assessment.where(id: params[:assessment_id]).first
+    source_assessment = Assessment.where(id: params[:source_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Source assessment was not found") unless source_assessment
     destination_assessment = Assessment.where(id: params[:destination_assessment_id]).first
     raise ActiveRecord::RecordNotFound.new("Destination assessment was not found") unless destination_assessment

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -192,7 +192,7 @@ class Assessment < ActiveRecord::Base
         source_assessment.current_assessment_xml &&
         destination_assessment.current_assessment_xml)
       move_questions_different_sections!(source_assessment, destination_assessment, guid, after_guid)
-    elsif (source_assessment.current_assessment_xml)
+    elsif (source_assessment.id == destination_assessment.id && source_assessment.current_assessment_xml)
       move_questions_same_section!(source_assessment, guid, after_guid)
     end
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -194,8 +194,6 @@ class Assessment < ActiveRecord::Base
           source_assessment.current_assessment_xml.xml,
           destination_assessment.current_assessment_xml.xml,
           guid)
-      puts "updated source xml = #{updated_source_xml}"
-      puts "updated destination xml = #{updated_destination_xml}"
       source_assessment.xml_file = updated_source_xml
       destination_assessment.xml_file = updated_destination_xml
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -190,7 +190,10 @@ class Assessment < ActiveRecord::Base
   def self.move_questions_for_guid!(source_assessment, destination_assessment, guid)
     if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(self.current_assessment_xml.xml, guid)
+        AssessmentXml.move_questions_for_guid(
+          source_assessment.current_assessment_xml.xml,
+          destination_assessment.current_assessment_xml.xml,
+          guid)
       source_assessment.xml_file = updated_source_xml
       destination_assessment.xml_file = updated_destination_xml
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -187,13 +187,14 @@ class Assessment < ActiveRecord::Base
     end
   end
 
-  def self.move_questions_for_guid!(source_assessment, destination_assessment, guid)
+  def self.move_questions_for_guid!(source_assessment, destination_assessment, guid, after_guid)
     if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_for_guid(
           source_assessment.current_assessment_xml.xml,
           destination_assessment.current_assessment_xml.xml,
-          guid)
+          guid,
+          after_guid)
       source_assessment.xml_file = updated_source_xml
       destination_assessment.xml_file = updated_destination_xml
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -190,10 +190,7 @@ class Assessment < ActiveRecord::Base
   def self.move_questions_for_guid!(source_assessment, destination_assessment, guid)
     if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(
-          source_assessment.current_assessment_xml.xml,
-          destination_assessment.current_assessment_xml.xml,
-          guid)
+        AssessmentXml.move_questions_for_guid(self.current_assessment_xml.xml, guid)
       source_assessment.xml_file = updated_source_xml
       destination_assessment.xml_file = updated_destination_xml
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -189,14 +189,22 @@ class Assessment < ActiveRecord::Base
 
   def self.move_questions_for_guid!(source_assessment, destination_assessment, guid, after_guid)
     if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(
+      if (source_assessment.id != destination_assessment.id)
+        updated_source_xml, updated_destination_xml =
+          AssessmentXml.move_questions_to_different_section_for_guid(
+            source_assessment.current_assessment_xml.xml,
+            destination_assessment.current_assessment_xml.xml,
+            guid,
+            after_guid)
+        source_assessment.xml_file = updated_source_xml
+        destination_assessment.xml_file = updated_destination_xml
+      else
+        updated_source_xml = AssessmentXml.move_questions_within_same_section_for_guid(
           source_assessment.current_assessment_xml.xml,
-          destination_assessment.current_assessment_xml.xml,
           guid,
           after_guid)
-      source_assessment.xml_file = updated_source_xml
-      destination_assessment.xml_file = updated_destination_xml
+        source_assessment.xml_file = updated_source_xml
+      end
     end
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -188,23 +188,23 @@ class Assessment < ActiveRecord::Base
   end
 
   def self.move_questions_for_guid!(source_assessment, destination_assessment, guid, after_guid)
-    if (source_assessment.current_assessment_xml && destination_assessment.current_assessment_xml)
-      if (source_assessment.id != destination_assessment.id)
-        updated_source_xml, updated_destination_xml =
-          AssessmentXml.move_questions_to_different_section_for_guid(
-            source_assessment.current_assessment_xml.xml,
-            destination_assessment.current_assessment_xml.xml,
-            guid,
-            after_guid)
-        source_assessment.xml_file = updated_source_xml
-        destination_assessment.xml_file = updated_destination_xml
-      else
-        updated_source_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+    if (source_assessment.id != destination_assessment.id &&
+      source_assessment.current_assessment_xml &&
+      destination_assessment.current_assessment_xml)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_to_different_section_for_guid(
           source_assessment.current_assessment_xml.xml,
+          destination_assessment.current_assessment_xml.xml,
           guid,
           after_guid)
-        source_assessment.xml_file = updated_source_xml
-      end
+      source_assessment.xml_file = updated_source_xml
+      destination_assessment.xml_file = updated_destination_xml
+    elsif (source_assessment.current_assessment_xml)
+      updated_source_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        source_assessment.current_assessment_xml.xml,
+        guid,
+        after_guid)
+      source_assessment.xml_file = updated_source_xml
     end
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -194,6 +194,8 @@ class Assessment < ActiveRecord::Base
           source_assessment.current_assessment_xml.xml,
           destination_assessment.current_assessment_xml.xml,
           guid)
+      puts "updated source xml = #{updated_source_xml}"
+      puts "updated destination xml = #{updated_destination_xml}"
       source_assessment.xml_file = updated_source_xml
       destination_assessment.xml_file = updated_destination_xml
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -189,22 +189,30 @@ class Assessment < ActiveRecord::Base
 
   def self.move_questions_for_guid!(source_assessment, destination_assessment, guid, after_guid)
     if (source_assessment.id != destination_assessment.id &&
-      source_assessment.current_assessment_xml &&
-      destination_assessment.current_assessment_xml)
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_to_different_section_for_guid(
-          source_assessment.current_assessment_xml.xml,
-          destination_assessment.current_assessment_xml.xml,
-          guid,
-          after_guid)
-      source_assessment.xml_file = updated_source_xml
-      destination_assessment.xml_file = updated_destination_xml
+        source_assessment.current_assessment_xml &&
+        destination_assessment.current_assessment_xml)
+      move_questions_different_sections!(source_assessment, destination_assessment, guid, after_guid)
     elsif (source_assessment.current_assessment_xml)
-      updated_source_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+      move_questions_same_section!(source_assessment, guid, after_guid)
+    end
+  end
+
+  def self.move_questions_different_sections!(source_assessment, destination_assessment, guid, after_guid)
+    updated_source_xml, updated_destination_xml =
+      AssessmentXml.move_questions_to_different_section_for_guid(
         source_assessment.current_assessment_xml.xml,
+        destination_assessment.current_assessment_xml.xml,
         guid,
         after_guid)
-      source_assessment.xml_file = updated_source_xml
-    end
+    source_assessment.xml_file = updated_source_xml
+    destination_assessment.xml_file = updated_destination_xml
+  end
+
+  def self.move_questions_same_section!(source_assessment, guid, after_guid)
+    updated_source_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+      source_assessment.current_assessment_xml.xml,
+      guid,
+      after_guid)
+    source_assessment.xml_file = updated_source_xml
   end
 end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -161,9 +161,9 @@ class AssessmentXml < ActiveRecord::Base
 
   def self.find_mirror_section_position(root_section, after_guid)
     if after_guid && after_guid.size > 0
-      after_guid_section = root_section.children.find { |section| is_section_for?(section, after_guid) }
-      if after_guid_section
-        return after_guid_section
+      after_guid_sections = root_section.children.select { |section| is_section_for?(section, after_guid) }
+      if !after_guid_sections.nil? && !after_guid_sections.empty?
+        return after_guid_sections.last
       end
     end
     return root_section.children.first # if no after_guid or the after_guid's home section could not be found,
@@ -230,9 +230,9 @@ class AssessmentXml < ActiveRecord::Base
       moving_section.default_namespace = "http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
 
       if after_guid && after_guid.size > 0
-        destination_section = root.children.find { |section| is_section_for?(section, after_guid) }
-        if destination_section
-          destination_section.next = moving_section
+        destination_sections = root.children.select { |section| is_section_for?(section, after_guid) }
+        if !destination_sections.nil? && !destination_sections.empty?
+          destination_sections.last.next = moving_section
         else
           root.children.before(moving_section)
         end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -127,7 +127,6 @@ class AssessmentXml < ActiveRecord::Base
     source_doc = Nokogiri::XML(source_xml_string)
     destination_doc = Nokogiri::XML(destination_xml_string)
 
-    destination_section = nil
     if root_section_contains_child_sections?(source_doc)
       source_doc.css('section section').each do |source_section|
         move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -194,6 +194,7 @@ class AssessmentXml < ActiveRecord::Base
             if metafield.css('fieldentry').children.to_s == guid.to_s
               # remove item with given outcome guid
               item.unlink # remove from source
+              item.default_namespace = "http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
               destination_section.add_child(item)
             end
           end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -205,7 +205,7 @@ class AssessmentXml < ActiveRecord::Base
     if source_section.to_s =~ /#{guid}/ # is the guid present in this section's xml?
       dest_root_section = root_section(destination_doc)
       if root_section_contains_child_sections?(destination_doc)
-        destination_section = create_mirror_section!(source_doc, source_section, dest_root_section)
+        destination_section = create_mirror_section!(source_doc, source_section, dest_root_section, guid)
       else
         destination_section = dest_root_section
       end
@@ -217,10 +217,14 @@ class AssessmentXml < ActiveRecord::Base
     doc.css('section section').any?
   end
 
-  def self.create_mirror_section!(source_document, source_section, destination_root_section)
+  def self.create_mirror_section!(source_document, source_section, destination_root_section, guid)
     mirror_section = Nokogiri::XML::Node.new "section", source_document
     if source_section['ident']
-      mirror_section['ident'] = source_section['ident']
+      if source_section['ident'] == "root_section"
+        mirror_section['ident'] = "copy_for_#{guid}"
+      else
+        mirror_section['ident'] = source_section['ident']
+      end
     end
     if source_section['title']
       mirror_section['title'] = source_section['title']

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -225,15 +225,21 @@ class AssessmentXml < ActiveRecord::Base
 
     # find section for guid
     moving_section = root.children.find { |section| is_section_for?(section, guid) }
-    moving_section.unlink
-    moving_section.default_namespace = "http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
+    if moving_section
+      moving_section.unlink
+      moving_section.default_namespace = "http://www.imsglobal.org/xsd/ims_qtiasiv1p2"
 
-    if after_guid && after_guid.size > 0
-      destination_section = root.children.find { |section| is_section_for?(section, after_guid) }
-      destination_section.next = moving_section
-    else
-      # not after, so it must be first
-      root.children.before(moving_section)
+      if after_guid && after_guid.size > 0
+        destination_section = root.children.find { |section| is_section_for?(section, after_guid) }
+        if destination_section
+          destination_section.next = moving_section
+        else
+          root.children.before(moving_section)
+        end
+      else
+        # not after, so it must be first
+        root.children.before(moving_section)
+      end
     end
 
     return doc.to_xml

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -184,10 +184,33 @@ class AssessmentXml < ActiveRecord::Base
     end
   end
 
-  def self.move_questions_for_guid(source_doc, destination_doc, guid)
-    # if destination root section has no child sections, then all matching items should be moved to root section
-    # otherwise, create "mirror" section in destination, and copy items into that
-    # after copy, if all items in destination are moved, remove the section - unless it is the root section!
+  def self.root_section(doc)
+    doc.css('assessment > section').first
+  end
+
+  def self.move_questions_for_guid!(source_doc, destination_doc, guid)
+    destination_section = nil
+    if root_section_contains_child_sections?(source_doc)
+      source_doc.css('section section').each do |source_section|
+        move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)
+      end
+      clear_empty_child_sections!(source_doc)
+    else
+      source_section = root_section(source_doc)
+      move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)
+    end
+  end
+
+  def self.move_questions_from_source_section!(source_doc, source_section, destination_doc, guid)
+    if source_section.to_s =~ /#{guid}/ # is the guid present in this section's xml?
+      dest_root_section = root_section(destination_doc)
+      if root_section_contains_child_sections?(destination_doc)
+        destination_section = create_mirror_section!(source_doc, source_section, dest_root_section)
+      else
+        destination_section = dest_root_section
+      end
+      move_items(source_section, destination_section, guid)
+    end
   end
 
   def self.root_section_contains_child_sections?(doc)
@@ -203,6 +226,7 @@ class AssessmentXml < ActiveRecord::Base
       mirror_section['title'] = source_section['title']
     end
     destination_root_section.children.last.next = mirror_section
+    mirror_section
   end
 
   # Moves all items from a given section for a given outcome guid to another section
@@ -228,7 +252,7 @@ class AssessmentXml < ActiveRecord::Base
             if metafield.css('fieldentry').children.to_s == guid.to_s
               # remove item with given outcome guid
               item.unlink # remove from source
-              destination_section.children.last.next = item # and add to destination
+              destination_section.add_child(item)
             end
           end
         end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -194,8 +194,8 @@ class AssessmentXml < ActiveRecord::Base
     doc.css('section section').any?
   end
 
-  def self.create_mirror_section!(source_section, destination_root_section)
-    mirror_section = Nokogiri::XML::Node.new "section"
+  def self.create_mirror_section!(source_document, source_section, destination_root_section)
+    mirror_section = Nokogiri::XML::Node.new "section", source_document
     if source_section['ident']
       mirror_section['ident'] = source_section['ident']
     end

--- a/app/models/assessment_xml.rb
+++ b/app/models/assessment_xml.rb
@@ -158,7 +158,7 @@ class AssessmentXml < ActiveRecord::Base
   def self.move_questions_for_guid(source_xml, destination_xml, guid)
     node = Nokogiri::XML(source_xml)
 
-    if node.css('section section').any?
+    if self.root_section_contains_child_sections?(node)
       node.css('section section').each do |section|
         remove_items_from_section(section, guid)
       end
@@ -169,15 +169,40 @@ class AssessmentXml < ActiveRecord::Base
     end
 
     # after moving items, remove section if section is now empty
-    if node.css('section section').any?
-      node.css('section section').each do |section|
+    clear_empty_child_sections!(node)
+
+    node.to_xml
+  end
+
+  def self.clear_empty_child_sections!(doc)
+    if root_section_contains_child_sections?(doc)
+      doc.css('section section').each do |section|
         unless section.css('item').any?
           section.remove
         end
       end
     end
+  end
 
-    node.to_xml
+  def self.move_questions_for_guid(source_doc, destination_doc, guid)
+    # if destination root section has no child sections, then all matching items should be moved to root section
+    # otherwise, create "mirror" section in destination, and copy items into that
+    # after copy, if all items in destination are moved, remove the section - unless it is the root section!
+  end
+
+  def self.root_section_contains_child_sections?(doc)
+    doc.css('section section').any?
+  end
+
+  def self.create_mirror_section!(source_section, destination_root_section)
+    mirror_section = Nokogiri::XML::Node.new "section"
+    if source_section['ident']
+      mirror_section['ident'] = source_section['ident']
+    end
+    if source_section['title']
+      mirror_section['title'] = source_section['title']
+    end
+    destination_root_section.children.last.next = mirror_section
   end
 
   # Moves all items from a given section for a given outcome guid to another section
@@ -200,11 +225,10 @@ class AssessmentXml < ActiveRecord::Base
       source_section.css('item').each do |item|
         if item.css('itemmetadata qtimetadata qtimetadatafield').any?
           item.css('itemmetadata qtimetadata qtimetadatafield').each do |metafield|
-            if metafield.css('fieldentry').children.to_s == guid.to_s && item.parent
-              section = item.parent
+            if metafield.css('fieldentry').children.to_s == guid.to_s
               # remove item with given outcome guid
-              section.unlink # remove from source
-              destination_section.children.last.next = section # and add to destination
+              item.unlink # remove from source
+              destination_section.children.last.next = item # and add to destination
             end
           end
         end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -745,7 +745,7 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       expect(retrieve_children_elements(source_section).length).to be 1
       expect(retrieve_children_elements(source_section.parent).length).to be 1
       expect(retrieve_children_elements(destination_section).length).to be 2
@@ -754,7 +754,7 @@ describe AssessmentXml do
     end
 
     it "will add ident and title to mirror section element if source element contains them" do
-source_xml = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -825,12 +825,88 @@ source_xml = Nokogiri::XML <<-EOSOURCEXML
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       expect(destination_section.children.last['ident']).to eq "170"
       expect(destination_section.children.last['title']).to eq "Liquidity Trap"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "170"
       expect(mirror_section['title']).to eq "Liquidity Trap"
+    end
+
+    it "will give mirror section a new name if copying from source root section" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='root_section']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      expect(destination_section.children.last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
     end
   end
 
@@ -1111,5 +1187,523 @@ source_xml = Nokogiri::XML <<-EOSOURCEXML
   end
 
   context "AssessmentXml.move_questions_for_guid!" do
+    it "should move items for every section which has an item with a matching guid" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="The Expenditure Multiplier" ident="2902">
+        <item title="" ident="1737">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 3
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[1]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[2]).length).to eq 1
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 3
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2]).length).to eq 1
+    end
+
+    it "should clear out sections if a child section has all items removed" do
+source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
+
+    it "should move items from root section if no child sections exist" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="5326">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Crowding Out</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(retrieve_children_elements(source_root).length).to eq 1
+      expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
+
+    it "should never remove root section, even if no items or sections are left in it" do
+      source_doc = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_doc = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(source_doc)
+      expect(source_root).not_to be_nil
+      expect(retrieve_children_elements(source_root).length).to eq 0
+      destination_root = AssessmentXml.root_section(destination_doc)
+      expect(retrieve_children_elements(destination_root).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -673,5 +673,159 @@ describe AssessmentXml do
   end
 
   context "AssessmentXml.create_mirror_section!" do
+    it "will create a mirror section" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      expect(retrieve_children_elements(source_section).length).to be 1
+      expect(retrieve_children_elements(source_section.parent).length).to be 1
+      expect(retrieve_children_elements(destination_section).length).to be 2
+    end
+
+    it "will add ident and title to mirror section element if source element contains them" do
+source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      expect(destination_section.children.last['ident']).to eq "170"
+      expect(destination_section.children.last['title']).to eq "Liquidity Trap"
+    end
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -178,7 +178,7 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_items_from_section" do
     before(:each) do
-      @source_xml = Nokogiri::HTML::DocumentFragment.parse <<-EOSOURCEXML
+      @source_xml = Nokogiri::XML <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -260,7 +260,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      @destination_xml = Nokogiri::HTML::DocumentFragment.parse <<-EODESTXML
+      @destination_xml = Nokogiri::XML <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -359,6 +359,248 @@ describe AssessmentXml do
       expect(retrieve_children_elements(original_source_parent).length).to eq 3
       expect(retrieve_children_elements(@destination_section).length).to eq 3
     end
+
+    it "will remove only those items in a section which match the guid" do
+      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+            <item title="" ident="5326">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Crowding Out</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+          <section title="The Expenditure Multiplier" ident="2902">
+            <item title="" ident="1737">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>The Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOSOURCEXML
+
+      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
+
+      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
+      expect(retrieve_children_elements(two_items_source_section).length).to eq 1
+      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
+      expect(retrieve_children_elements(@destination_section).length).to eq 4
+    end
+
+    it "will remove all of the items from the source section if they match on guid" do
+      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+            <item title="" ident="5326">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Crowding Out</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+          <section title="The Expenditure Multiplier" ident="2902">
+            <item title="" ident="1737">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>The Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOSOURCEXML
+
+      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
+      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
+      expect(retrieve_children_elements(two_items_source_section).length).to eq 0
+      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
+      expect(retrieve_children_elements(@destination_section).length).to eq 5
+    end
   end
 
+  context "AssessmentXml.clear_empty_child_sections!" do
+    it "will clear sections which are empty" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      section = xml.css("section[ident='root_section']").first
+      
+      AssessmentXml.clear_empty_child_sections!(xml)
+      expect(retrieve_children_elements(section).length).to be 0
+    end
+
+    it "will not clear sections which have items in them" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      section = xml.css("section[ident='root_section']").first
+
+      AssessmentXml.clear_empty_child_sections!(xml)
+      expect(retrieve_children_elements(section).length).to be 1
+    end
+  end
+
+  context "AssessmentXml.root_section_contains_child_sections?" do
+  end
+
+  context "AssessmentXml.create_mirror_section!" do
+  end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -178,20 +178,89 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_items_from_section" do
     before(:each) do
-      @source_xml = Nokogiri::XML <<-EOSOURCEXML
+      @source_xml = Nokogiri::HTML::DocumentFragment.parse <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      #{@liquidity_trap_section}
-      #{@expenditure_multiplier_section}
-      #{@crowding_out_section}
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="The Expenditure Multiplier" ident="2902">
+        <item title="" ident="1737">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+      <section title="Crowding Out" ident="5247">
+        <item title="" ident="5326">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Crowding Out</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      @destination_xml = Nokogiri::XML <<-EODESTXML
+      @destination_xml = Nokogiri::HTML::DocumentFragment.parse <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -278,814 +347,18 @@ describe AssessmentXml do
     end
 
     it "should move the item from the source to the destination, if the guid is found in the item in the source" do
+      original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
-      expect(retrieve_children_elements(@source_section).length).to eq 0
-      expect(retrieve_children_elements(@source_section.parent).length).to eq 3
-      expect(retrieve_children_elements(@destination_section).length).to eq 4
+      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 2
+      expect(@destination_section.children.select { |child| child.element? }.length).to eq 4
     end
 
     it "should leave the two XMLs unchanged if guid is not found in the source" do
       original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, 'adfb2853-598d-48f7-8206-50edaac3a16c')
-      expect(retrieve_children_elements(original_source_parent).length).to eq 3
-      expect(retrieve_children_elements(@destination_section).length).to eq 3
-    end
-
-    it "will remove only those items in a section which match the guid" do
-      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-            <item title="" ident="5326">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Crowding Out</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
-          #{@expenditure_multiplier_section}
-        </section>
-      </assessment>
-    </questestinterop>
-          EOSOURCEXML
-
-      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
-
-      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
-      expect(retrieve_children_elements(two_items_source_section).length).to eq 1
-      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
-      expect(retrieve_children_elements(@destination_section).length).to eq 4
-    end
-
-    it "will remove all of the items from the source section if they match on guid" do
-      two_items_source_xml = Nokogiri::XML <<-EOSOURCEXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-            <item title="" ident="5326">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Crowding Out</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
-          #{@expenditure_multiplier_section}
-        </section>
-      </assessment>
-    </questestinterop>
-          EOSOURCEXML
-
-      two_items_source_section = two_items_source_xml.css("section[ident='170']").first
-      AssessmentXml.move_items(two_items_source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
-      expect(retrieve_children_elements(two_items_source_section).length).to eq 0
-      expect(retrieve_children_elements(two_items_source_section.parent).length).to eq 2
-      expect(retrieve_children_elements(@destination_section).length).to eq 5
+      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 3
+      expect(@destination_section.children.select { |child| child.element? }.length).to eq 3
     end
   end
 
-  context "AssessmentXml.clear_empty_child_sections!" do
-    it "will clear sections which are empty" do
-      xml = Nokogiri::XML <<-EOXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          <section title="Liquidity Trap" ident="170">
-          </section>
-        </section>
-      </assessment>
-    </questestinterop>
-          EOXML
-      section = xml.css("section[ident='root_section']").first
-      
-      AssessmentXml.clear_empty_child_sections!(xml)
-      expect(retrieve_children_elements(section).length).to be 0
-    end
-
-    it "will not clear sections which have items in them" do
-      xml = Nokogiri::XML <<-EOXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          #{@liquidity_trap_section}
-        </section>
-      </assessment>
-    </questestinterop>
-          EOXML
-      section = xml.css("section[ident='root_section']").first
-
-      AssessmentXml.clear_empty_child_sections!(xml)
-      expect(retrieve_children_elements(section).length).to be 1
-    end
-  end
-
-  context "AssessmentXml.root_section_contains_child_sections?" do
-    it "will return true if the root section has child sections" do
-      xml = Nokogiri::XML <<-EOXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          #{@liquidity_trap_section}
-        </section>
-      </assessment>
-    </questestinterop>
-          EOXML
-      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_truthy
-    end
-
-    it "will return false if the root section does not have child sections" do
-      xml = Nokogiri::XML <<-EOXML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-        <section ident="root_section">
-          <item title="" ident="7773">
-            <itemmetadata>
-              <qtimetadata>
-                <qtimetadatafield>
-                  <fieldlabel>question_type</fieldlabel>
-                  <fieldentry>multiple_answers_question</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_guid</fieldlabel>
-                  <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_short_title</fieldlabel>
-                  <fieldentry>Liquidity Trap</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_long_title</fieldlabel>
-                  <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                </qtimetadatafield>
-              </qtimetadata>
-            </itemmetadata>
-          </item>
-        </section>
-      </assessment>
-    </questestinterop>
-          EOXML
-      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_falsy
-    end
-  end
-
-  context "AssessmentXml.create_mirror_section!" do
-    it "will create a mirror section" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML @standard_destination_xml
-
-      source_section = source_xml.css("section[ident='170']").first
-      destination_section = destination_xml.css("section[ident='root_section']").first
-
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      expect(retrieve_children_elements(source_section).length).to be 1
-      expect(retrieve_children_elements(source_section.parent).length).to be 1
-      expect(retrieve_children_elements(destination_section).length).to be 2
-      expect(mirror_section).not_to be_nil
-      expect(mirror_section['ident']).to eq "170"
-    end
-
-    it "will add ident and title to mirror section element if source element contains them" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML @standard_destination_xml
-
-      source_section = source_xml.css("section[ident='170']").first
-      destination_section = destination_xml.css("section[ident='root_section']").first
-
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      expect(destination_section.children.last['ident']).to eq "170"
-      expect(destination_section.children.last['title']).to eq "Liquidity Trap"
-      expect(mirror_section).not_to be_nil
-      expect(mirror_section['ident']).to eq "170"
-      expect(mirror_section['title']).to eq "Liquidity Trap"
-    end
-
-    it "will give mirror section a new name if copying from source root section" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML @standard_destination_xml
-
-      source_section = source_xml.css("section[ident='root_section']").first
-      destination_section = destination_xml.css("section[ident='root_section']").first
-
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      expect(destination_section.children.last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
-      expect(mirror_section).not_to be_nil
-      expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
-    end
-  end
-
-  context "AssessmentXml.root_section" do
-    it "finds a section for the root section" do
-      xml = Nokogiri::XML @standard_destination_xml
-
-      section = AssessmentXml.root_section(xml)
-      expect(section).not_to be_nil
-      expect(section['ident']).to eq "root_section"
-    end
-  end
-
-  context "AssessmentXml.move_questions_from_source_section!" do
-    it "moves questions from source section into mirror section in destination if destination root has sections" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML @standard_destination_xml
-
-      source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      expect(retrieve_children_elements(source_section).length).to eq 0
-      expect(retrieve_children_elements(source_section.parent).length).to eq 1
-      destination_root_section = AssessmentXml.root_section(destination_xml)
-      expect(retrieve_children_elements(destination_root_section).length).to eq 2
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root_section).last).length).to eq 1
-    end
-
-    it "moves questions from source section into destination root section if destination root does not have child sections" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <item title="" ident="1998">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Business Cycle</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
-
-      source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      expect(retrieve_children_elements(source_section).length).to eq 0
-      expect(retrieve_children_elements(source_section.parent).length).to eq 1
-      destination_root_section = AssessmentXml.root_section(destination_xml)
-      expect(retrieve_children_elements(destination_root_section).length).to eq 2
-    end
-
-    it "does not move any questions if no guid matches" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML @standard_destination_xml
-
-      source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48")
-      expect(retrieve_children_elements(source_section.parent).length).to eq 1
-      expect(retrieve_children_elements(source_section).length).to eq 1
-      destination_root_section = AssessmentXml.root_section(destination_xml)
-      expect(retrieve_children_elements(destination_root_section).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root_section).first).length).to eq 1
-    end
-  end
-
-  context "AssessmentXml.move_questions_for_guid" do
-    it "should move items for every section which has an item with a matching guid" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      <section title="The Expenditure Multiplier" ident="2902">
-        <item title="" ident="1737">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      #{@crowding_out_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = @standard_destination_xml
-
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
-      expect(retrieve_children_elements(source_root).length).to eq 3
-      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(source_root)[1]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(source_root)[2]).length).to eq 1
-      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
-      expect(retrieve_children_elements(destination_root).length).to eq 3
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
-      # verify that no namespace exists on item elements
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0])[0].name).to eq "item"
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1])[0].name).to eq "item"
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2])[0].name).to eq "item"
-    end
-
-    it "should clear out sections if a child section has all items removed" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      #{@crowding_out_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
-      expect(retrieve_children_elements(source_root).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
-      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
-      expect(retrieve_children_elements(destination_root).length).to eq 2
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
-    end
-
-    it "should move items from root section if no child sections exist" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="1737">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="5326">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Crowding Out</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
-      expect(retrieve_children_elements(source_root).length).to eq 1
-      expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
-      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
-      expect(retrieve_children_elements(destination_root).length).to eq 2
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
-    end
-
-    it "should never remove root section, even if no items or sections are left in it" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="1737">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
-      expect(source_root).not_to be_nil
-      expect(retrieve_children_elements(source_root).length).to eq 0
-      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
-      expect(retrieve_children_elements(destination_root).length).to eq 2
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
-    end
-  end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -578,8 +578,8 @@ describe AssessmentXml do
       destination_section = destination_xml.css("section[ident='root_section']").first
 
       mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
-      expect(destination_section.children.last['ident']).to eq "170"
-      expect(destination_section.children.last['title']).to eq "Liquidity Trap"
+      expect(retrieve_children_elements(destination_section).last['ident']).to eq "170"
+      expect(retrieve_children_elements(destination_section).last['title']).to eq "Liquidity Trap"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "170"
       expect(mirror_section['title']).to eq "Liquidity Trap"
@@ -624,7 +624,7 @@ describe AssessmentXml do
       destination_section = destination_xml.css("section[ident='root_section']").first
 
       mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
-      expect(destination_section.children.last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
+      expect(retrieve_children_elements(destination_section).last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
     end
@@ -931,8 +931,8 @@ describe AssessmentXml do
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
       destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
-      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
     end
 
     it "should move items from root section if no child sections exist" do

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -8,118 +8,160 @@ end
 describe AssessmentXml do
   before do
     @xml = open('./spec/fixtures/sections_assessment.xml').read
+
+    @business_cycle_item = <<-BCIXML
+    <item title="" ident="1998">
+      <itemmetadata>
+        <qtimetadata>
+          <qtimetadatafield>
+            <fieldlabel>question_type</fieldlabel>
+            <fieldentry>multiple_answers_question</fieldentry>
+          </qtimetadatafield>
+          <qtimetadatafield>
+            <fieldlabel>outcome_guid</fieldlabel>
+            <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+          </qtimetadatafield>
+          <qtimetadatafield>
+            <fieldlabel>outcome_short_title</fieldlabel>
+            <fieldentry>The Business Cycle</fieldentry>
+          </qtimetadatafield>
+          <qtimetadatafield>
+            <fieldlabel>outcome_long_title</fieldlabel>
+            <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+          </qtimetadatafield>
+        </qtimetadata>
+      </itemmetadata>
+    </item>
+    BCIXML
+
     @standard_destination_xml = <<-EODESTXML
       <?xml version="1.0" encoding="UTF-8"?>
       <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
         <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
           <section ident="root_section">
             <section title="The Business Cycle" ident="4112">
-              <item title="" ident="1998">
-                <itemmetadata>
-                  <qtimetadata>
-                    <qtimetadatafield>
-                      <fieldlabel>question_type</fieldlabel>
-                      <fieldentry>multiple_answers_question</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_guid</fieldlabel>
-                      <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_short_title</fieldlabel>
-                      <fieldentry>The Business Cycle</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_long_title</fieldlabel>
-                      <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-                    </qtimetadatafield>
-                  </qtimetadata>
-                </itemmetadata>
-              </item>
+              #{@business_cycle_item}
             </section>
           </section>
         </assessment>
       </questestinterop>
     EODESTXML
 
+    @liquity_trap_item = <<-LTIXML
+      <item title="" ident="7773">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    LTIXML
+
     @liquidity_trap_section = <<-LTSXML
       <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@liquity_trap_item}
       </section>
     LTSXML
 
+    @expenditure_multiplier_item1 = <<-EXIXML
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    EXIXML
+
+    @expenditure_multiplier_item2 = <<-EXI2XML
+      <item title="" ident="1737">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    EXI2XML
+
     @expenditure_multiplier_section = <<-EMSXML
       <section title="The Expenditure Multiplier" ident="2902">
-        <item title="" ident="1737">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@expenditure_multiplier_item2}
       </section>
     EMSXML
 
+    @crowding_out_item = <<-COIXML
+      <item title="" ident="5326">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>Crowding Out</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    COIXML
+
     @crowding_out_section = <<-COSXML
       <section title="Crowding Out" ident="5247">
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@crowding_out_item}
       </section>
     COSXML
   end
@@ -197,28 +239,7 @@ describe AssessmentXml do
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
     <section ident="root_section">
       <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@business_cycle_item}
       </section>
       <section title="Defining Economic Growth" ident="8139">
         <item title="" ident="9436">
@@ -298,50 +319,8 @@ describe AssessmentXml do
       <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
         <section ident="root_section">
           <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-            <item title="" ident="5326">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Crowding Out</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
+            #{@liquity_trap_item}
+            #{@crowding_out_item}
           </section>
           #{@expenditure_multiplier_section}
         </section>
@@ -364,28 +343,7 @@ describe AssessmentXml do
       <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
         <section ident="root_section">
           <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
+            #{@liquity_trap_item}
             <item title="" ident="5326">
               <itemmetadata>
                 <qtimetadata>
@@ -481,28 +439,7 @@ describe AssessmentXml do
     <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
       <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
         <section ident="root_section">
-          <item title="" ident="7773">
-            <itemmetadata>
-              <qtimetadata>
-                <qtimetadatafield>
-                  <fieldlabel>question_type</fieldlabel>
-                  <fieldentry>multiple_answers_question</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_guid</fieldlabel>
-                  <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_short_title</fieldlabel>
-                  <fieldentry>Liquidity Trap</fieldentry>
-                </qtimetadatafield>
-                <qtimetadatafield>
-                  <fieldlabel>outcome_long_title</fieldlabel>
-                  <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                </qtimetadatafield>
-              </qtimetadata>
-            </itemmetadata>
-          </item>
+          #{@liquity_trap_item}
         </section>
       </assessment>
     </questestinterop>
@@ -519,28 +456,7 @@ describe AssessmentXml do
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
       <section ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@liquity_trap_item}
       </section>
     </section>
   </assessment>
@@ -591,28 +507,7 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
+      #{@liquity_trap_item}
     </section>
   </assessment>
 </questestinterop>
@@ -627,6 +522,64 @@ describe AssessmentXml do
       expect(retrieve_children_elements(destination_section).last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
+    end
+
+    it "will put the mirror section after the first section containing the after_guid" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML @standard_destination_xml
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml,
+        source_section,
+        destination_section,
+        "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+        "6538eeef-76a6-4971-a730-356b299ded48")
+      expect(retrieve_children_elements(destination_section).last['ident']).to eq "170"
+      expect(retrieve_children_elements(destination_section).last['title']).to eq "Liquidity Trap"
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "170"
+      expect(mirror_section['title']).to eq "Liquidity Trap"
+    end
+
+    it "will put the mirror section first if after_guid is nil" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML @standard_destination_xml
+
+      source_section = source_xml.css("section[ident='170']").first
+      destination_section = destination_xml.css("section[ident='root_section']").first
+
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml,
+        source_section,
+        destination_section,
+        "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+        nil)
+      expect(retrieve_children_elements(destination_section).first['ident']).to eq "170"
+      expect(retrieve_children_elements(destination_section).first['title']).to eq "Liquidity Trap"
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "170"
+      expect(mirror_section['title']).to eq "Liquidity Trap"
     end
   end
 
@@ -681,28 +634,7 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
     <section ident="root_section">
-      <item title="" ident="1998">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Business Cycle</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
+      #{@business_cycle_item}
     </section>
   </assessment>
 </questestinterop>
@@ -748,96 +680,12 @@ describe AssessmentXml do
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
       <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@liquity_trap_item}
+        #{@crowding_out_item}
       </section>
       <section title="The Expenditure Multiplier" ident="2902">
-        <item title="" ident="1737">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@expenditure_multiplier_item1}
+        #{@crowding_out_item}
       </section>
       #{@crowding_out_section}
     </section>
@@ -873,28 +721,7 @@ describe AssessmentXml do
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
       <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
+        #{@liquity_trap_item}
         <item title="" ident="5326">
           <itemmetadata>
             <qtimetadata>
@@ -941,72 +768,9 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="1737">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="5326">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Crowding Out</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
+      #{@liquity_trap_item}
+      #{@expenditure_multiplier_item1}
+      #{@crowding_out_item}
     </section>
   </assessment>
 </questestinterop>
@@ -1032,50 +796,8 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <item title="" ident="7773">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
-      <item title="" ident="1737">
-        <itemmetadata>
-          <qtimetadata>
-            <qtimetadatafield>
-              <fieldlabel>question_type</fieldlabel>
-              <fieldentry>multiple_answers_question</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_guid</fieldlabel>
-              <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_short_title</fieldlabel>
-              <fieldentry>The Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-            <qtimetadatafield>
-              <fieldlabel>outcome_long_title</fieldlabel>
-              <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-            </qtimetadatafield>
-          </qtimetadata>
-        </itemmetadata>
-      </item>
+      #{@liquity_trap_item}
+      #{@expenditure_multiplier_item1}
     </section>
   </assessment>
 </questestinterop>

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1357,8 +1357,12 @@ describe AssessmentXml do
       destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
+      # verify that no namespace exists on item elements
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0])[0].name).to eq "item"
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1])[0].name).to eq "item"
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2]).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root)[2])[0].name).to eq "item"
     end
 
     it "should clear out sections if a child section has all items removed" do

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -183,78 +183,9 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      <section title="The Expenditure Multiplier" ident="2902">
-        <item title="" ident="1737">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      <section title="Crowding Out" ident="5247">
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@liquidity_trap_section}
+      #{@expenditure_multiplier_section}
+      #{@crowding_out_section}
     </section>
   </assessment>
 </questestinterop>
@@ -412,30 +343,7 @@ describe AssessmentXml do
               </itemmetadata>
             </item>
           </section>
-          <section title="The Expenditure Multiplier" ident="2902">
-            <item title="" ident="1737">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>The Expenditure Multiplier</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
+          #{@expenditure_multiplier_section}
         </section>
       </assessment>
     </questestinterop>
@@ -501,30 +409,7 @@ describe AssessmentXml do
               </itemmetadata>
             </item>
           </section>
-          <section title="The Expenditure Multiplier" ident="2902">
-            <item title="" ident="1737">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>adfb2853-598d-48f7-8206-50edaac3a16c</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>The Expenditure Multiplier</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the significance of the Expenditure Multiplier</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
+          #{@expenditure_multiplier_section}
         </section>
       </assessment>
     </questestinterop>
@@ -563,30 +448,7 @@ describe AssessmentXml do
     <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
       <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
         <section ident="root_section">
-          <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
+          #{@liquidity_trap_section}
         </section>
       </assessment>
     </questestinterop>
@@ -605,30 +467,7 @@ describe AssessmentXml do
     <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
       <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
         <section ident="root_section">
-          <section title="Liquidity Trap" ident="170">
-            <item title="" ident="7773">
-              <itemmetadata>
-                <qtimetadata>
-                  <qtimetadatafield>
-                    <fieldlabel>question_type</fieldlabel>
-                    <fieldentry>multiple_answers_question</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_guid</fieldlabel>
-                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_short_title</fieldlabel>
-                    <fieldentry>Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                  <qtimetadatafield>
-                    <fieldlabel>outcome_long_title</fieldlabel>
-                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-                  </qtimetadatafield>
-                </qtimetadata>
-              </itemmetadata>
-            </item>
-          </section>
+          #{@liquidity_trap_section}
         </section>
       </assessment>
     </questestinterop>
@@ -708,39 +547,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
@@ -759,68 +566,13 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@liquidity_trap_section}
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
@@ -866,39 +618,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='root_section']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
@@ -912,39 +632,7 @@ describe AssessmentXml do
 
   context "AssessmentXml.root_section" do
     it "finds a section for the root section" do
-      xml = Nokogiri::XML <<-EOXML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-        <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-          <section ident="root_section">
-            <section title="The Business Cycle" ident="4112">
-              <item title="" ident="1998">
-                <itemmetadata>
-                  <qtimetadata>
-                    <qtimetadatafield>
-                      <fieldlabel>question_type</fieldlabel>
-                      <fieldentry>multiple_answers_question</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_guid</fieldlabel>
-                      <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_short_title</fieldlabel>
-                      <fieldentry>The Business Cycle</fieldentry>
-                    </qtimetadatafield>
-                    <qtimetadatafield>
-                      <fieldlabel>outcome_long_title</fieldlabel>
-                      <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-                    </qtimetadatafield>
-                  </qtimetadata>
-                </itemmetadata>
-              </item>
-            </section>
-          </section>
-        </assessment>
-      </questestinterop>
-      EOXML
+      xml = Nokogiri::XML @standard_destination_xml
 
       section = AssessmentXml.root_section(xml)
       expect(section).not_to be_nil
@@ -959,68 +647,13 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@liquidity_trap_section}
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
       AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
@@ -1037,30 +670,7 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@liquidity_trap_section}
     </section>
   </assessment>
 </questestinterop>
@@ -1112,68 +722,13 @@ describe AssessmentXml do
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
     <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        <item title="" ident="7773">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@liquidity_trap_section}
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
       AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48")
@@ -1284,68 +839,13 @@ describe AssessmentXml do
           </itemmetadata>
         </item>
       </section>
-      <section title="Crowding Out" ident="5247">
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@crowding_out_section}
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      destination_xml = @standard_destination_xml
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
@@ -1417,71 +917,14 @@ describe AssessmentXml do
           </itemmetadata>
         </item>
       </section>
-      <section title="Crowding Out" ident="5247">
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>129039d4-84ae-4b3d-8593-2917acdea4e2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
+      #{@crowding_out_section}
     </section>
   </assessment>
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
-
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
@@ -1568,42 +1011,8 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
-
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
@@ -1668,42 +1077,8 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      <section title="The Business Cycle" ident="4112">
-        <item title="" ident="1998">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>The Business Cycle</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
-
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(source_root).not_to be_nil
       expect(retrieve_children_elements(source_root).length).to eq 0

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -347,17 +347,17 @@ describe AssessmentXml do
     end
 
     it "should move the item from the source to the destination, if the guid is found in the item in the source" do
-      original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, '65b449c6-afb8-416f-960b-8aaf69cb4ed2')
-      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 2
-      expect(@destination_section.children.select { |child| child.element? }.length).to eq 4
+      expect(retrieve_children_elements(@source_section).length).to eq 0
+      expect(retrieve_children_elements(@source_section.parent).length).to eq 3
+      expect(retrieve_children_elements(@destination_section).length).to eq 4
     end
 
     it "should leave the two XMLs unchanged if guid is not found in the source" do
       original_source_parent = @source_section.parent
       AssessmentXml.move_items(@source_section, @destination_section, 'adfb2853-598d-48f7-8206-50edaac3a16c')
-      expect(original_source_parent.children.select { |child| child.element? }.length).to eq 3
-      expect(@destination_section.children.select { |child| child.element? }.length).to eq 3
+      expect(retrieve_children_elements(original_source_parent).length).to eq 3
+      expect(retrieve_children_elements(@destination_section).length).to eq 3
     end
   end
 

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -845,7 +845,7 @@ describe AssessmentXml do
       expect(retrieve_children_elements(root)[2]['ident']).to eq "2902"
     end
 
-    it "should move a section to the first child of root child if after guid is nil" do
+    it "should move a section to the first child of root section if after guid is nil" do
       xml = <<-EOSOURCEXML
         <?xml version="1.0" encoding="UTF-8"?>
         <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
@@ -869,6 +869,58 @@ describe AssessmentXml do
       expect(retrieve_children_elements(root)[0]['ident']).to eq "5247"
       expect(retrieve_children_elements(root)[1]['ident']).to eq "170"
       expect(retrieve_children_elements(root)[2]['ident']).to eq "2902"
+    end
+
+    it "should move a section to the first child of root section if section matching after guid cannot be found" do
+      xml = <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+              #{@expenditure_multiplier_section}
+              #{@crowding_out_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        xml,
+        "129039d4-84ae-4b3d-8593-2917acdea4e2",
+        "44444444-4444-4444-4444-44444444a4e4")
+      root = AssessmentXml.root_section(Nokogiri::XML(updated_xml))
+      expect(root).not_to be_nil
+      expect(retrieve_children_elements(root).length).to eq 3
+      expect(retrieve_children_elements(root)[0]['ident']).to eq "5247"
+      expect(retrieve_children_elements(root)[1]['ident']).to eq "170"
+      expect(retrieve_children_elements(root)[2]['ident']).to eq "2902"
+    end
+
+    it "should leave quiz unchanged if moving section cannot be found" do
+      xml = <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+              #{@expenditure_multiplier_section}
+              #{@crowding_out_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        xml,
+        "44444444-4444-4444-4444-44444444a4e4",
+        "129039d4-84ae-4b3d-8593-2917acdea4e2")
+      root = AssessmentXml.root_section(Nokogiri::XML(updated_xml))
+      expect(root).not_to be_nil
+      expect(retrieve_children_elements(root).length).to eq 3
+      expect(retrieve_children_elements(root)[0]['ident']).to eq "170"
+      expect(retrieve_children_elements(root)[1]['ident']).to eq "2902"
+      expect(retrieve_children_elements(root)[2]['ident']).to eq "5247"
     end
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -599,6 +599,77 @@ describe AssessmentXml do
   end
 
   context "AssessmentXml.root_section_contains_child_sections?" do
+    it "will return true if the root section has child sections" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <section title="Liquidity Trap" ident="170">
+            <item title="" ident="7773">
+              <itemmetadata>
+                <qtimetadata>
+                  <qtimetadatafield>
+                    <fieldlabel>question_type</fieldlabel>
+                    <fieldentry>multiple_answers_question</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_guid</fieldlabel>
+                    <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_short_title</fieldlabel>
+                    <fieldentry>Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                  <qtimetadatafield>
+                    <fieldlabel>outcome_long_title</fieldlabel>
+                    <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                  </qtimetadatafield>
+                </qtimetadata>
+              </itemmetadata>
+            </item>
+          </section>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_truthy
+    end
+
+    it "will return false if the root section does not have child sections" do
+      xml = Nokogiri::XML <<-EOXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+      <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+        <section ident="root_section">
+          <item title="" ident="7773">
+            <itemmetadata>
+              <qtimetadata>
+                <qtimetadatafield>
+                  <fieldlabel>question_type</fieldlabel>
+                  <fieldentry>multiple_answers_question</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_guid</fieldlabel>
+                  <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_short_title</fieldlabel>
+                  <fieldentry>Liquidity Trap</fieldentry>
+                </qtimetadatafield>
+                <qtimetadatafield>
+                  <fieldlabel>outcome_long_title</fieldlabel>
+                  <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+                </qtimetadatafield>
+              </qtimetadata>
+            </itemmetadata>
+          </item>
+        </section>
+      </assessment>
+    </questestinterop>
+          EOXML
+      expect(AssessmentXml.root_section_contains_child_sections?(xml)).to be_falsy
+    end
   end
 
   context "AssessmentXml.create_mirror_section!" do

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -672,7 +672,7 @@ describe AssessmentXml do
     end
   end
 
-  context "AssessmentXml.move_questions_for_guid" do
+  context "AssessmentXml.move_questions_to_different_section_for_guid" do
     it "should move items for every section which has an item with a matching guid" do
       source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -694,7 +694,7 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml,
+        AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
           @standard_destination_xml,
           "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
           "6538eeef-76a6-4971-a730-356b299ded48")
@@ -752,7 +752,7 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", nil)
+        AssessmentXml.move_questions_to_different_section_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", nil)
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
@@ -777,7 +777,7 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml,
+        AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
           @standard_destination_xml,
           "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
           "6538eeef-76a6-4971-a730-356b299ded48")
@@ -804,7 +804,7 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml,
+        AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
           @standard_destination_xml,
           "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
           "6538eeef-76a6-4971-a730-356b299ded48")
@@ -815,6 +815,60 @@ describe AssessmentXml do
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
+    end
+  end
+
+  context "AssessmentXml.move_questions_within_same_section_for_guid" do
+    it "should move a section to after the section with the child guid" do
+      xml = <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+              #{@crowding_out_section}
+              #{@expenditure_multiplier_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        xml,
+        "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+        "129039d4-84ae-4b3d-8593-2917acdea4e2")
+      root = AssessmentXml.root_section(Nokogiri::XML(updated_xml))
+      expect(root).not_to be_nil
+      expect(retrieve_children_elements(root).length).to eq 3
+      expect(retrieve_children_elements(root)[0]['ident']).to eq "5247"
+      expect(retrieve_children_elements(root)[1]['ident']).to eq "170"
+      expect(retrieve_children_elements(root)[2]['ident']).to eq "2902"
+    end
+
+    it "should move a section to the first child of root child if after guid is nil" do
+      xml = <<-EOSOURCEXML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+            <section ident="root_section">
+              #{@liquidity_trap_section}
+              #{@expenditure_multiplier_section}
+              #{@crowding_out_section}
+            </section>
+          </assessment>
+        </questestinterop>
+      EOSOURCEXML
+
+      updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        xml,
+        "129039d4-84ae-4b3d-8593-2917acdea4e2",
+        nil)
+      root = AssessmentXml.root_section(Nokogiri::XML(updated_xml))
+      expect(root).not_to be_nil
+      expect(retrieve_children_elements(root).length).to eq 3
+      expect(retrieve_children_elements(root)[0]['ident']).to eq "5247"
+      expect(retrieve_children_elements(root)[1]['ident']).to eq "170"
+      expect(retrieve_children_elements(root)[2]['ident']).to eq "2902"
     end
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -512,19 +512,7 @@ describe AssessmentXml do
 
   context "AssessmentXml.create_mirror_section!" do
     it "will create a mirror section" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section ident="170">
-        #{@liquity_trap_item}
-      </section>
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti("<section ident=\"170\">#{@liquity_trap_item}</section>")
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
@@ -539,17 +527,7 @@ describe AssessmentXml do
     end
 
     it "will add ident and title to mirror section element if source element contains them" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
@@ -564,17 +542,7 @@ describe AssessmentXml do
     end
 
     it "will give mirror section a new name if copying from source root section" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquity_trap_item}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti(@liquity_trap_item)
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='root_section']").first
@@ -587,17 +555,7 @@ describe AssessmentXml do
     end
 
     it "will put the mirror section after the first section containing the after_guid" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
@@ -616,17 +574,7 @@ describe AssessmentXml do
     end
 
     it "will put the mirror section first if after_guid is nil" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
@@ -657,17 +605,7 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_questions_from_source_section!" do
     it "moves questions from source section into mirror section in destination if destination root has sections" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
@@ -680,27 +618,8 @@ describe AssessmentXml do
     end
 
     it "moves questions from source section into destination root section if destination root does not have child sections" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
-
-      destination_xml = Nokogiri::XML <<-EODESTXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
-    <section ident="root_section">
-      #{@business_cycle_item}
-    </section>
-  </assessment>
-</questestinterop>
-      EODESTXML
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
+      destination_xml = Nokogiri::XML build_qti(@business_cycle_item)
 
       source_section = source_xml.css("section[ident='170']").first
       AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
@@ -711,16 +630,7 @@ describe AssessmentXml do
     end
 
     it "does not move any questions if no guid matches" do
-      source_xml = Nokogiri::XML <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquidity_trap_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
+      source_xml = Nokogiri::XML build_qti(@liquidity_trap_section)
 
       destination_xml = Nokogiri::XML @standard_destination_xml
 
@@ -736,24 +646,10 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_questions_to_different_section_for_guid" do
     it "should move items for every section which has an item with a matching guid" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        #{@liquity_trap_item}
-        #{@crowding_out_item}
-      </section>
-      <section title="The Expenditure Multiplier" ident="2902">
-        #{@expenditure_multiplier_item1}
-        #{@crowding_out_item}
-      </section>
-      #{@crowding_out_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
+      local_liquidity_trap_section = "<section title=\"Liquidity Trap\" ident=\"170\">#{@liquity_trap_item}#{@crowding_out_item}</section>"
+      local_expenditure_multiplier_section = "<section title=\"The Expenditure Multiplier\" ident=\"2902\">#{@expenditure_multiplier_item1}#{@crowding_out_item}</section>"
+
+      source_xml = build_qti(local_liquidity_trap_section, local_expenditure_multiplier_section, @crowding_out_section)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
@@ -777,41 +673,35 @@ describe AssessmentXml do
     end
 
     it "should clear out sections if a child section has all items removed" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      <section title="Liquidity Trap" ident="170">
-        #{@liquity_trap_item}
-        <item title="" ident="5326">
-          <itemmetadata>
-            <qtimetadata>
-              <qtimetadatafield>
-                <fieldlabel>question_type</fieldlabel>
-                <fieldentry>multiple_answers_question</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_guid</fieldlabel>
-                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_short_title</fieldlabel>
-                <fieldentry>Crowding Out</fieldentry>
-              </qtimetadatafield>
-              <qtimetadatafield>
-                <fieldlabel>outcome_long_title</fieldlabel>
-                <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
-              </qtimetadatafield>
-            </qtimetadata>
-          </itemmetadata>
-        </item>
-      </section>
-      #{@crowding_out_section}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
+      local_liquidity_trap_section = <<-LLTSXML
+         <section title="Liquidity Trap" ident="170">
+           #{@liquity_trap_item}
+           <item title="" ident="5326">
+             <itemmetadata>
+               <qtimetadata>
+                 <qtimetadatafield>
+                   <fieldlabel>question_type</fieldlabel>
+                   <fieldentry>multiple_answers_question</fieldentry>
+                 </qtimetadatafield>
+                 <qtimetadatafield>
+                   <fieldlabel>outcome_guid</fieldlabel>
+                   <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+                 </qtimetadatafield>
+                 <qtimetadatafield>
+                   <fieldlabel>outcome_short_title</fieldlabel>
+                   <fieldentry>Crowding Out</fieldentry>
+                 </qtimetadatafield>
+                 <qtimetadatafield>
+                   <fieldlabel>outcome_long_title</fieldlabel>
+                   <fieldentry>Explain how Crowding Out weakens the effectiveness of fiscal policy</fieldentry>
+                 </qtimetadatafield>
+               </qtimetadata>
+             </itemmetadata>
+           </item>
+         </section>
+      LLTSXML
+
+      source_xml = build_qti(local_liquidity_trap_section, @crowding_out_section)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", nil)
@@ -825,18 +715,7 @@ describe AssessmentXml do
     end
 
     it "should move items from root section if no child sections exist" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquity_trap_item}
-      #{@expenditure_multiplier_item1}
-      #{@crowding_out_item}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
+      source_xml = build_qti(@liquity_trap_item, @expenditure_multiplier_item1, @crowding_out_item)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
@@ -853,17 +732,7 @@ describe AssessmentXml do
     end
 
     it "should never remove root section, even if no items or sections are left in it" do
-      source_xml = <<-EOSOURCEXML
-<?xml version="1.0" encoding="UTF-8"?>
-<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-    <section ident="root_section">
-      #{@liquity_trap_item}
-      #{@expenditure_multiplier_item1}
-    </section>
-  </assessment>
-</questestinterop>
-      EOSOURCEXML
+      source_xml = build_qti(@liquity_trap_item, @expenditure_multiplier_item1)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
@@ -880,30 +749,8 @@ describe AssessmentXml do
     end
 
     it "should move items for every section which has an item with a matching guid" do
-      source_xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@crowding_out_section}
-              #{@expenditure_multiplier_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
-
-      dest_xml = <<-EODESTXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trip_section1}
-              #{@liquidity_trip_section2}
-              #{@crowding_out_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EODESTXML
+      source_xml = build_qti(@crowding_out_section, @expenditure_multiplier_section)
+      dest_xml = build_qti(@liquidity_trip_section1, @liquidity_trip_section2, @crowding_out_section)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
@@ -922,30 +769,8 @@ describe AssessmentXml do
     end
 
     it "should preserve order of sections which are moved" do
-      source_xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trip_section1}
-              #{@liquidity_trip_section2}
-              #{@expenditure_multiplier_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
-
-      dest_xml = <<-EODESTXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@crowding_out_section}
-              #{@expenditure_multiplier_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EODESTXML
+      source_xml = build_qti(@liquidity_trip_section1, @liquidity_trip_section2, @expenditure_multiplier_section)
+      dest_xml = build_qti(@crowding_out_section, @expenditure_multiplier_section)
 
       updated_source_xml, updated_destination_xml =
         AssessmentXml.move_questions_to_different_section_for_guid(source_xml,
@@ -966,18 +791,9 @@ describe AssessmentXml do
 
   context "AssessmentXml.move_questions_within_same_section_for_guid" do
     it "should move a section to after the section with the child guid" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-              #{@crowding_out_section}
-              #{@expenditure_multiplier_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@liquidity_trap_section,
+        @crowding_out_section,
+        @expenditure_multiplier_section)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -992,18 +808,9 @@ describe AssessmentXml do
     end
 
     it "should move a section to the first child of root section if after guid is nil" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-              #{@expenditure_multiplier_section}
-              #{@crowding_out_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@liquidity_trap_section,
+        @expenditure_multiplier_section,
+        @crowding_out_section)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -1018,18 +825,9 @@ describe AssessmentXml do
     end
 
     it "should move a section to the first child of root section if section matching after guid cannot be found" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-              #{@expenditure_multiplier_section}
-              #{@crowding_out_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@liquidity_trap_section,
+        @expenditure_multiplier_section,
+        @crowding_out_section)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -1044,18 +842,9 @@ describe AssessmentXml do
     end
 
     it "should leave quiz unchanged if moving section cannot be found" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trap_section}
-              #{@expenditure_multiplier_section}
-              #{@crowding_out_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@liquidity_trap_section,
+        @expenditure_multiplier_section,
+        @crowding_out_section)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -1070,19 +859,10 @@ describe AssessmentXml do
     end
 
     it "should choose the last section if multiple sections have the same guid" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@liquidity_trip_section1}
-              #{@liquidity_trip_section2}
-              #{@crowding_out_section}
-              #{@expenditure_multiplier_section}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@liquidity_trip_section1,
+        @liquidity_trip_section2,
+        @crowding_out_section,
+        @expenditure_multiplier_section)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -1098,19 +878,10 @@ describe AssessmentXml do
     end
 
     it "should move all questions from multiple sections" do
-      xml = <<-EOSOURCEXML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
-          <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
-            <section ident="root_section">
-              #{@crowding_out_section}
-              #{@expenditure_multiplier_section}
-              #{@liquidity_trip_section1}
-              #{@liquidity_trip_section2}
-            </section>
-          </assessment>
-        </questestinterop>
-      EOSOURCEXML
+      xml = build_qti(@crowding_out_section,
+        @expenditure_multiplier_section,
+        @liquidity_trip_section1,
+        @liquidity_trip_section2)
 
       updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
         xml,
@@ -1124,5 +895,41 @@ describe AssessmentXml do
       expect(retrieve_children_elements(root)[2]['ident']).to eq "175"
       expect(retrieve_children_elements(root)[3]['ident']).to eq "2902"
     end
+
+    it "should move all questions from multiple sections, even if they are separated" do
+      xml = build_qti(@crowding_out_section,
+        @expenditure_multiplier_section,
+        @liquidity_trip_section1,
+        "<section title=\"The Business Cycle\" ident=\"4112\">#{@business_cycle_item}</section>",
+        @liquidity_trip_section2)
+
+      updated_xml = AssessmentXml.move_questions_within_same_section_for_guid(
+        xml,
+        "65b449c6-afb8-416f-960b-8aaf69cb4ed7",
+        "129039d4-84ae-4b3d-8593-2917acdea4e2")
+      root = AssessmentXml.root_section(Nokogiri::XML(updated_xml))
+      expect(root).not_to be_nil
+      expect(retrieve_children_elements(root).length).to eq 5
+      expect(retrieve_children_elements(root)[0]['ident']).to eq "5247"
+      expect(retrieve_children_elements(root)[1]['ident']).to eq "174"
+      expect(retrieve_children_elements(root)[2]['ident']).to eq "175"
+      expect(retrieve_children_elements(root)[3]['ident']).to eq "2902"
+      expect(retrieve_children_elements(root)[4]['ident']).to eq "4112"
+    end
+  end
+
+  private
+
+  def build_qti(*more)
+    xml = <<-QTIXML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+        <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+          <section ident="root_section">
+            #{more.join("")}
+          </section>
+        </assessment>
+      </questestinterop>
+    QTIXML
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -552,7 +552,7 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
       expect(retrieve_children_elements(source_section).length).to be 1
       expect(retrieve_children_elements(source_section.parent).length).to be 1
       expect(retrieve_children_elements(destination_section).length).to be 2
@@ -577,7 +577,7 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
       expect(destination_section.children.last['ident']).to eq "170"
       expect(destination_section.children.last['title']).to eq "Liquidity Trap"
       expect(mirror_section).not_to be_nil
@@ -623,7 +623,7 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='root_section']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
       expect(destination_section.children.last['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
       expect(mirror_section).not_to be_nil
       expect(mirror_section['ident']).to eq "copy_for_65b449c6-afb8-416f-960b-8aaf69cb4ed2"
@@ -656,7 +656,7 @@ describe AssessmentXml do
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
       expect(retrieve_children_elements(source_section).length).to eq 0
       expect(retrieve_children_elements(source_section.parent).length).to eq 1
       destination_root_section = AssessmentXml.root_section(destination_xml)
@@ -709,7 +709,7 @@ describe AssessmentXml do
       EODESTXML
 
       source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", "6538eeef-76a6-4971-a730-356b299ded48")
       expect(retrieve_children_elements(source_section).length).to eq 0
       expect(retrieve_children_elements(source_section.parent).length).to eq 1
       destination_root_section = AssessmentXml.root_section(destination_xml)
@@ -731,7 +731,7 @@ describe AssessmentXml do
       destination_xml = Nokogiri::XML @standard_destination_xml
 
       source_section = source_xml.css("section[ident='170']").first
-      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48")
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48", nil)
       expect(retrieve_children_elements(source_section.parent).length).to eq 1
       expect(retrieve_children_elements(source_section).length).to eq 1
       destination_root_section = AssessmentXml.root_section(destination_xml)
@@ -845,10 +845,11 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_xml = @standard_destination_xml
-
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml,
+          @standard_destination_xml,
+          "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+          "6538eeef-76a6-4971-a730-356b299ded48")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
@@ -924,7 +925,7 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2", nil)
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
@@ -1012,7 +1013,10 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml,
+          @standard_destination_xml,
+          "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+          "6538eeef-76a6-4971-a730-356b299ded48")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
@@ -1078,7 +1082,10 @@ describe AssessmentXml do
       EOSOURCEXML
 
       updated_source_xml, updated_destination_xml =
-        AssessmentXml.move_questions_for_guid(source_xml, @standard_destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+        AssessmentXml.move_questions_for_guid(source_xml,
+          @standard_destination_xml,
+          "65b449c6-afb8-416f-960b-8aaf69cb4ed2",
+          "6538eeef-76a6-4971-a730-356b299ded48")
       source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(source_root).not_to be_nil
       expect(retrieve_children_elements(source_root).length).to eq 0

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1176,7 +1176,6 @@ describe AssessmentXml do
       EODESTXML
 
       source_section = source_xml.css("section[ident='170']").first
-      source_section = source_xml.css("section[ident='170']").first
       AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48")
       expect(retrieve_children_elements(source_section.parent).length).to eq 1
       expect(retrieve_children_elements(source_section).length).to eq 1

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -745,10 +745,12 @@ describe AssessmentXml do
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
       expect(retrieve_children_elements(source_section).length).to be 1
       expect(retrieve_children_elements(source_section.parent).length).to be 1
       expect(retrieve_children_elements(destination_section).length).to be 2
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "170"
     end
 
     it "will add ident and title to mirror section element if source element contains them" do
@@ -823,9 +825,291 @@ source_xml = Nokogiri::XML <<-EOSOURCEXML
       source_section = source_xml.css("section[ident='170']").first
       destination_section = destination_xml.css("section[ident='root_section']").first
 
-      AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
+      mirror_section = AssessmentXml.create_mirror_section!(source_xml, source_section, destination_section)
       expect(destination_section.children.last['ident']).to eq "170"
       expect(destination_section.children.last['title']).to eq "Liquidity Trap"
+      expect(mirror_section).not_to be_nil
+      expect(mirror_section['ident']).to eq "170"
+      expect(mirror_section['title']).to eq "Liquidity Trap"
     end
+  end
+
+  context "AssessmentXml.root_section" do
+    it "finds a section for the root section" do
+      xml = Nokogiri::XML <<-EOXML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+        <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+          <section ident="root_section">
+            <section title="The Business Cycle" ident="4112">
+              <item title="" ident="1998">
+                <itemmetadata>
+                  <qtimetadata>
+                    <qtimetadatafield>
+                      <fieldlabel>question_type</fieldlabel>
+                      <fieldentry>multiple_answers_question</fieldentry>
+                    </qtimetadatafield>
+                    <qtimetadatafield>
+                      <fieldlabel>outcome_guid</fieldlabel>
+                      <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+                    </qtimetadatafield>
+                    <qtimetadatafield>
+                      <fieldlabel>outcome_short_title</fieldlabel>
+                      <fieldentry>The Business Cycle</fieldentry>
+                    </qtimetadatafield>
+                    <qtimetadatafield>
+                      <fieldlabel>outcome_long_title</fieldlabel>
+                      <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+                    </qtimetadatafield>
+                  </qtimetadata>
+                </itemmetadata>
+              </item>
+            </section>
+          </section>
+        </assessment>
+      </questestinterop>
+      EOXML
+
+      section = AssessmentXml.root_section(xml)
+      expect(section).not_to be_nil
+      expect(section['ident']).to eq "root_section"
+    end
+  end
+
+  context "AssessmentXml.move_questions_from_source_section!" do
+    it "moves questions from source section into mirror section in destination if destination root has sections" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      expect(retrieve_children_elements(source_section).length).to eq 0
+      expect(retrieve_children_elements(source_section.parent).length).to eq 1
+      destination_root_section = AssessmentXml.root_section(destination_xml)
+      expect(retrieve_children_elements(destination_root_section).length).to eq 2
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root_section).last).length).to eq 1
+    end
+
+    it "moves questions from source section into destination root section if destination root does not have child sections" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <item title="" ident="1998">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_answers_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_guid</fieldlabel>
+              <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_short_title</fieldlabel>
+              <fieldentry>The Business Cycle</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>outcome_long_title</fieldlabel>
+              <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      expect(retrieve_children_elements(source_section).length).to eq 0
+      expect(retrieve_children_elements(source_section.parent).length).to eq 1
+      destination_root_section = AssessmentXml.root_section(destination_xml)
+      expect(retrieve_children_elements(destination_root_section).length).to eq 2
+    end
+
+    it "does not move any questions if no guid matches" do
+      source_xml = Nokogiri::XML <<-EOSOURCEXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
+    <section ident="root_section">
+      <section title="Liquidity Trap" ident="170">
+        <item title="" ident="7773">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>65b449c6-afb8-416f-960b-8aaf69cb4ed2</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Explain the implications of a Liquidity Trap</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EOSOURCEXML
+
+      destination_xml = Nokogiri::XML <<-EODESTXML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
+    <section ident="root_section">
+      <section title="The Business Cycle" ident="4112">
+        <item title="" ident="1998">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield>
+                <fieldlabel>question_type</fieldlabel>
+                <fieldentry>multiple_answers_question</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_guid</fieldlabel>
+                <fieldentry>6538eeef-76a6-4971-a730-356b299ded48</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_short_title</fieldlabel>
+                <fieldentry>The Business Cycle</fieldentry>
+              </qtimetadatafield>
+              <qtimetadatafield>
+                <fieldlabel>outcome_long_title</fieldlabel>
+                <fieldentry>Describe the business cycle and its primary phases</fieldentry>
+              </qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+        </item>
+      </section>
+    </section>
+  </assessment>
+</questestinterop>
+      EODESTXML
+
+      source_section = source_xml.css("section[ident='170']").first
+      source_section = source_xml.css("section[ident='170']").first
+      AssessmentXml.move_questions_from_source_section!(source_xml, source_section, destination_xml, "6538eeef-76a6-4971-a730-356b299ded48")
+      expect(retrieve_children_elements(source_section.parent).length).to eq 1
+      expect(retrieve_children_elements(source_section).length).to eq 1
+      destination_root_section = AssessmentXml.root_section(destination_xml)
+      expect(retrieve_children_elements(destination_root_section).length).to eq 1
+      expect(retrieve_children_elements(retrieve_children_elements(destination_root_section).first).length).to eq 1
+    end
+  end
+
+  context "AssessmentXml.move_questions_for_guid!" do
   end
 end

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -1186,9 +1186,9 @@ describe AssessmentXml do
     end
   end
 
-  context "AssessmentXml.move_questions_for_guid!" do
+  context "AssessmentXml.move_questions_for_guid" do
     it "should move items for every section which has an item with a matching guid" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1314,7 +1314,7 @@ describe AssessmentXml do
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1348,13 +1348,14 @@ describe AssessmentXml do
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[1]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[2]).length).to eq 1
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 3
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 1
@@ -1362,7 +1363,7 @@ describe AssessmentXml do
     end
 
     it "should clear out sections if a child section has all items removed" do
-source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1442,7 +1443,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1476,18 +1477,19 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(source_root)[0]).length).to eq 1
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
     end
 
     it "should move items from root section if no child sections exist" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1563,7 +1565,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1597,18 +1599,19 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(retrieve_children_elements(source_root).length).to eq 1
       expect(retrieve_children_elements(source_root)[0].node_name).to eq "item"
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2
     end
 
     it "should never remove root section, even if no items or sections are left in it" do
-      source_doc = Nokogiri::XML <<-EOSOURCEXML
+      source_xml = <<-EOSOURCEXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">
@@ -1662,7 +1665,7 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EOSOURCEXML
 
-      destination_doc = Nokogiri::XML <<-EODESTXML
+      destination_xml = <<-EODESTXML
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment title="Show What You Know: Macro Workings" ident="if8390a2480634681a1608f47c0a529fe_swyk">
@@ -1696,11 +1699,12 @@ source_doc = Nokogiri::XML <<-EOSOURCEXML
 </questestinterop>
       EODESTXML
 
-      AssessmentXml.move_questions_for_guid!(source_doc, destination_doc, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
-      source_root = AssessmentXml.root_section(source_doc)
+      updated_source_xml, updated_destination_xml =
+        AssessmentXml.move_questions_for_guid(source_xml, destination_xml, "65b449c6-afb8-416f-960b-8aaf69cb4ed2")
+      source_root = AssessmentXml.root_section(Nokogiri::XML(updated_source_xml))
       expect(source_root).not_to be_nil
       expect(retrieve_children_elements(source_root).length).to eq 0
-      destination_root = AssessmentXml.root_section(destination_doc)
+      destination_root = AssessmentXml.root_section(Nokogiri::XML(updated_destination_xml))
       expect(retrieve_children_elements(destination_root).length).to eq 2
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[0]).length).to eq 1
       expect(retrieve_children_elements(retrieve_children_elements(destination_root)[1]).length).to eq 2

--- a/spec/models/assessment_xml_spec.rb
+++ b/spec/models/assessment_xml_spec.rb
@@ -921,7 +921,7 @@ describe AssessmentXml do
   private
 
   def build_qti(*more)
-    xml = <<-QTIXML
+    <<-QTIXML
       <?xml version="1.0" encoding="UTF-8"?>
       <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
         <assessment title="Show What You Know: Policy Application" ident="ib116e1ef09a84426bab060f8d936d8b7_swyk">

--- a/spec/support/nokogiri_helpers.rb
+++ b/spec/support/nokogiri_helpers.rb
@@ -2,4 +2,8 @@ module NokogiriHelpers
   def retrieve_children_elements(node)
     node.children.select { |child| child.element? }
   end
+
+  def retrieve_child_sections(node)
+    node.children.select { |child| child.name == "section" }
+  end
 end


### PR DESCRIPTION
The order of quiz items should mirror the order of the sections with a study plan.  Therefore, when a section is moved, the quiz items for that section should be moved to the best determinable spot so that the order is preserved.

I believe that there are four cases to check for this on:
[ ] root section has items, moved from source study plan to destination study plan
[X] root section has sections with items, moved from source study plan to destination study plan
[ ] root section has items, section moved within a single plan
[ ] root section has sections with items, section moved within a single plan

In cases where root section has items and we have an after_guid, let's look through all the items.  Once we find the first item using the after_guid, we'll treat every other item that has that same after_guid as a section.  We will then add the moved quiz items to after the last item in that pseudo-section.