### PR TITLE
Disable email health checks

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,18 +39,18 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.smtp_settings = {
-    :user_name => Rails.application.secrets.email_provider_username,
-    :password => Rails.application.secrets.email_provider_password,
-    :domain => Rails.application.secrets.domain_name,
-    :address => Rails.application.secrets.email_provider_address,
-    :port => 587,
-    :authentication => :plain,
-    :enable_starttls_auto => true
-  }
+  # config.action_mailer.smtp_settings = {
+  #   :user_name => Rails.application.secrets.email_provider_username,
+  #   :password => Rails.application.secrets.email_provider_password,
+  #   :domain => Rails.application.secrets.domain_name,
+  #   :address => Rails.application.secrets.email_provider_address,
+  #   :port => 587,
+  #   :authentication => :plain,
+  #   :enable_starttls_auto => true
+  # }
 
   # ActionMailer Config
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   # Send email in development mode?

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,9 @@
+HealthCheck.setup do |config|
+
+  # Timeout in seconds used when checking smtp server
+  # config.smtp_timeout = 30.0
+
+  # Or to exclude one check:
+  config.standard_checks -= [ 'emailconf', 'email' ]
+
+end

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -3,7 +3,7 @@ HealthCheck.setup do |config|
   # Timeout in seconds used when checking smtp server
   # config.smtp_timeout = 30.0
 
-  # Or to exclude one check:
+  # Exclude standard e-mail health checks
   config.standard_checks -= [ 'emailconf', 'email' ]
 
 end


### PR DESCRIPTION
The health check gem appears to be causing slow response times.
Because OEA does not use email, this commit adds a config that
disables email health checks in an attempt to address the
slowness issue we're seeing witht he health check gem.