### PR TITLE
Update health_check gem to 2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'groupdate' # for grouping the chart data by date
 
 # Monitoring
 gem 'newrelic_rpm'
-gem 'health_check'
+gem 'health_check', '~> 2.8'
 gem 'rack-ssl-enforcer'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,8 +143,8 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashie (3.4.1)
-    health_check (1.5.1)
-      rails (>= 2.3.0)
+    health_check (2.8.0)
+      railties (~> 4.0)
     hike (1.2.3)
     hitimes (1.2.2)
     httparty (0.13.4)
@@ -399,7 +399,7 @@ DEPENDENCIES
   guard-bundler
   guard-rails
   guard-rspec
-  health_check
+  health_check (~> 2.8)
   httparty
   hub
   ims-lti (~> 1.1.8)
@@ -445,4 +445,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.15.4
+   1.16.4


### PR DESCRIPTION
The config that was added to remove email health checks has syntax
relevant to later version of the health_check gem (and that does
not work on the version installed in OEA). This commit updates
the health_check gem to the latest compatible version with Rails 4.