### PR TITLE
macOS Mojave 'libstdc++' Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ $ npm install moment@2.10.6
 $ npm install react-tinymce@0.2.3
 ```
 
+#### ATTENTION: macOS Mojave Users
+
+If you run into errors regarding `libstdc++` and you are running macOS 10.14 (Mojave) or later,
+you may have to manually install this library (which is considered deprecated in favor of libc++).
+
+1.  Download both the latest version of XCode 10+ and install it
+2.  Get the deprecated lib files from [this repo](https://github.com/Kila2/libstdc-.6.0.9.tbd)
+3.  Follow their readme and put the files in the necessary XCode App folders
+4.  In addition, add the lib files to Command Line Tools: `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`
+5.  Finally, add these lines to your `.bash_profile` file.
+    
+    ```bash
+    export CXXFLAGS="-mmacosx-version-min=10.9"
+    export LDFLAGS="-mmacosx-version-min=10.9"
+    ```
 
 ### 5. Start the server and React "hot reloading"
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you get this error on MacOS:
 
 try this to get nokogiri to install
 ```
-gem install nokogiri -v 1.6.6.2  -- --use-system-libraries
+gem install nokogiri -v '1.6.6.2' -- --use-system-libraries=true --with-xml2-include="$(xcrun --show-sdk-path)"/usr/include/libxml2
 ```
 
 If you get an error stating that the `eventmachine` gem did not install, try:


### PR DESCRIPTION
# Problem

As of macOS 10.14+ (Mojave) and XCode 10+, the libstdc++ library was removed from XCode in favor of libc++.  Node v0.10.37, upon which this project's front end depends, needs the removed library to compile the front end assets.

# Solution (sort of)

Update the Readme documentation to help users on Mojave to install the deprecated library and point the system's C compiler to it so that OEA can be installed locally.