### PR TITLE
Make wait modal render in center of screen

### DIFF
--- a/client/js/components/assessments/summative/feature/WaitModal.jsx
+++ b/client/js/components/assessments/summative/feature/WaitModal.jsx
@@ -12,6 +12,7 @@ export default class WaitModal extends React.Component {
     };
 
     this.escFunction = this.escFunction.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
   }
 
   componentWillMount() {
@@ -98,10 +99,13 @@ export default class WaitModal extends React.Component {
         backgroundColor: "#fff",
         borderRadius: "6px",
         boxShadow: "0 2px 16px 0 rgba(33, 43, 54, 0.08), 0 31px 41px 0 rgba(33, 43, 54, 0.2)",
-        margin: this.state.windowWidth <= 500 ? 0 : "12% auto",
         maxWidth: "620px",
         minHeight: "311px",
-        height: this.state.windowWidth <= 500 ? "100%" : "auto"
+        height: this.state.windowWidth <= 500 ? "100%" : "auto",
+        position: "relative",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%) !important"
       },
       titleBar: {
         position: "relative",


### PR DESCRIPTION
# Problem

Sometimes when there's a lot of content on the screen that requires the user to scroll down, when they go to click in and take the test, the Wait modal will render outside the user's view, which causes confusion.

# Solution

This PR simply addresses some troublesome CSS and uses top/left and translate properties to render the modal in the center of the screen, regardless of how much the user may have scrolled.