### PR TITLE
Dont send the userAssessmentId to xml api endpoint

### DIFF
--- a/client/js/actions/review_assessment.js
+++ b/client/js/actions/review_assessment.js
@@ -48,6 +48,7 @@ export default {
 
     if(resultId){
       url = url + "?assessment_result_id=" + resultId;
+      Dispatcher.dispatch({ action: Constants.CHECK_ASSESSMENT_XML, resultId });
     }
 
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);

--- a/client/js/components/assessments/summative/StartSummative.jsx
+++ b/client/js/components/assessments/summative/StartSummative.jsx
@@ -44,7 +44,7 @@ export default class StartSummative extends React.Component {
   componentDidMount() {
     CommHandler.sendSizeThrottled();
     CommHandler.showLMSNavigation();
-  }
+}
 
   renderAttemptsFeedback() {
     // if there are assessment attempts to map over ...

--- a/client/js/stores/review_assessment.js
+++ b/client/js/stores/review_assessment.js
@@ -30,6 +30,7 @@ var _inDraftOriginals = {};
 var _assessmentResult = null;
 var _attemptedAssessmentsResults = null;
 var _assessmentResultState = NOT_LOADED;
+var _retrievedXmlAssessmentResult = null;
 
 function parseAssessmentResult(result){
   _assessmentResult = JSON.parse(result);
@@ -421,6 +422,9 @@ var ReviewAssessmentStore = assign({}, StoreCommon, {
   },
   getAttemptedAssessments(){
     return _attemptedAssessmentsResults;
+  },
+  retrievedXmlAssessmentResult(){
+    return _retrievedXmlAssessmentResult;
   }
 });
 
@@ -556,6 +560,10 @@ Dispatcher.register(function(payload) {
     case Constants.SAVE_ASSESSMENT:
       loadAssessment(payload);
       window.onbeforeunload = null;
+      break;
+
+    case Constants.CHECK_ASSESSMENT_XML:
+      _retrievedXmlAssessmentResult = payload.resultId;
       break;
 
     default:


### PR DESCRIPTION
The userAssessmentId was being sent as the assessment_result_id to
the /student_review_xml endpoint, which was, in rare cases, causing
users to see incorrect attempt feedback for the assessment.

This removes the line that was passing userAssessmentId to actions,
and because an argument isn't being passed it now defaults to null
which makes it so the query param '?assessment_result_id=' doesn't
get tacked on to the API call, since we don't need it anyway.