### PR TITLE
Remove argument when hitting API endpoint for XML

### DIFF
--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -204,17 +204,8 @@ class Api::AssessmentsController < Api::ApiController
   # version of the xml that has answers in it.
   def student_review_show_xml
     assessment = Assessment.where(id: params[:assessment_id], account: current_account).first
-    xml = nil
 
-    if params[:assessment_result_id]
-      ar = AssessmentResult.find(params[:assessment_result_id])
-
-      if ar.assessment_xml && (ar.assessment_xml.kind == 'summative' || ar.assessment_xml.kind == 'qti')
-        xml = ar.assessment_xml.xml
-      end
-    end
-
-    render :xml => xml || assessment.xml_without_answers
+    render :xml => assessment.xml_without_answers
   end
 
   # *******************************************************************

--- a/client/js/actions/review_assessment.js
+++ b/client/js/actions/review_assessment.js
@@ -42,13 +42,9 @@ export default {
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);
   },
 
-  loadAssessmentXmlForStudentReview(settings, assessmentId, resultId=null){
+  loadAssessmentXmlForStudentReview(settings, assessmentId){
     Dispatcher.dispatch({ action: Constants.REVIEW_ASSESSMENT_LOAD_PENDING });
     var url = settings.apiUrl + "api/assessments/" + assessmentId + "/student_review_xml";
-
-    if(resultId){
-      url = url + "?assessment_result_id=" + resultId;
-    }
 
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);
   },

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -84,8 +84,7 @@ export default class Start extends BaseComponent {
 
       ReviewAssessmentActions.loadAssessmentXmlForStudentReview(
         SettingsStore.current(),
-        SettingsStore.current().assessmentId,
-        SettingsStore.current().userAssessmentId
+        SettingsStore.current().assessmentId
       );
     }
 


### PR DESCRIPTION
## What?

We're hitting the following endpoint correctly:

https://assessments.lumenlearning.com/api/assessments/<id>/student_review?uaid=<some_id>

but the next call is passing that UserAssessment id as the Assessment Result id, which is what's grabbing the xml for economics (instead of the correct xml for biology):

https://assessments.lumenlearning.com/api/assessments/<id>/student_review_xml?assessment_result_id=<some_id>

## How?

In the start.jsx root component for assessment start pages, after the component mounts it invokes two actions methods that fire off two API calls, one to fetch the assessment review data and one to fetch the assessment xml.  Because the second call was being passed the wrong value (user_assessment_id) as assessment_result_id, it was constructing a URL that hits the endpoint with a query param for a specific assessment_result_id (which is wrong).

With some digging, it appears that we shouldn’t be passing the third argument to the action method because we don’t actually need a specific assessment result for that API call, since all we care about is the xml coming back (we are getting the result info from the first API call which is functioning as expected).

## The Fix?

Stop sending the third argument that was setting the query param on the call to the API endpoint for assessment xml.