### PR TITLE
Sprint 25 bug fixes

### DIFF
--- a/app/controllers/api/assessments_controller.rb
+++ b/app/controllers/api/assessments_controller.rb
@@ -204,17 +204,8 @@ class Api::AssessmentsController < Api::ApiController
   # version of the xml that has answers in it.
   def student_review_show_xml
     assessment = Assessment.where(id: params[:assessment_id], account: current_account).first
-    xml = nil
 
-    if params[:assessment_result_id]
-      ar = AssessmentResult.find(params[:assessment_result_id])
-
-      if ar.assessment_xml && (ar.assessment_xml.kind == 'summative' || ar.assessment_xml.kind == 'qti')
-        xml = ar.assessment_xml.xml
-      end
-    end
-
-    render :xml => xml || assessment.xml_without_answers
+    render :xml => assessment.xml_without_answers
   end
 
   # *******************************************************************

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 <% else -%>
   <%= render partial: "assessments/assessment_setup" %>
-  <div id="assessment-container"></div>
+  <div id="assessment-container" style="width: 95%; margin: 0 auto;"></div>
   <%= webpack_manifest_script %>
   <%= webpack_bundle_tag 'app' %>
 <% end -%>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 <% else -%>
   <%= render partial: "assessments/assessment_setup" %>
-  <div id="assessment-container" style="padding: 0 25px"></div>
+  <div id="assessment-container" style="padding: 0"></div>
   <%= webpack_manifest_script %>
   <%= webpack_bundle_tag 'app' %>
 <% end -%>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 <% else -%>
   <%= render partial: "assessments/assessment_setup" %>
-  <div id="assessment-container" style="width: 95%; margin: 0 auto;"></div>
+  <div id="assessment-container" style="padding: 0 25px"></div>
   <%= webpack_manifest_script %>
   <%= webpack_bundle_tag 'app' %>
 <% end -%>

--- a/client/js/actions/review_assessment.js
+++ b/client/js/actions/review_assessment.js
@@ -42,13 +42,9 @@ export default {
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);
   },
 
-  loadAssessmentXmlForStudentReview(settings, assessmentId, resultId=null){
+  loadAssessmentXmlForStudentReview(settings, assessmentId){
     Dispatcher.dispatch({ action: Constants.REVIEW_ASSESSMENT_LOAD_PENDING });
     var url = settings.apiUrl + "api/assessments/" + assessmentId + "/student_review_xml";
-
-    if(resultId){
-      url = url + "?assessment_result_id=" + resultId;
-    }
 
     Api.get(Constants.REVIEW_ASSESSMENT_LOADED, url);
   },

--- a/client/js/components/assessment_results/result_styles.js
+++ b/client/js/components/assessment_results/result_styles.js
@@ -32,7 +32,7 @@ export default{
       },
       assessmentContainer:{
         marginTop: "0px",
-        padding: "0 16px",
+        padding: "0 25px",
         boxShadow: isFormative ? "" : theme.assessmentContainerBoxShadow,
         borderRadius: theme.assessmentContainerBorderRadius
       },

--- a/client/js/components/assessment_results/result_styles.js
+++ b/client/js/components/assessment_results/result_styles.js
@@ -33,6 +33,7 @@ export default{
       assessmentContainer:{
         marginTop: "0px",
         padding: "0 25px",
+        backgroundColor: "#fff",
         boxShadow: isFormative ? "" : theme.assessmentContainerBoxShadow,
         borderRadius: theme.assessmentContainerBorderRadius
       },

--- a/client/js/components/assessments/summative/StartSummative.jsx
+++ b/client/js/components/assessments/summative/StartSummative.jsx
@@ -161,7 +161,7 @@ export default class StartSummative extends React.Component {
         margin: 0
       },
       footerWrapper: {
-        marginTop: "20px"
+        padding: "20px 0"
       },
       footerHeading: {
         color: "#212b36",

--- a/client/js/components/assessments/summative/feature/WaitModal.jsx
+++ b/client/js/components/assessments/summative/feature/WaitModal.jsx
@@ -12,6 +12,7 @@ export default class WaitModal extends React.Component {
     };
 
     this.escFunction = this.escFunction.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
   }
 
   componentWillMount() {
@@ -98,10 +99,13 @@ export default class WaitModal extends React.Component {
         backgroundColor: "#fff",
         borderRadius: "6px",
         boxShadow: "0 2px 16px 0 rgba(33, 43, 54, 0.08), 0 31px 41px 0 rgba(33, 43, 54, 0.2)",
-        margin: this.state.windowWidth <= 500 ? 0 : "12% auto",
         maxWidth: "620px",
         minHeight: "311px",
-        height: this.state.windowWidth <= 500 ? "100%" : "auto"
+        height: this.state.windowWidth <= 500 ? "100%" : "auto",
+        position: "relative",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%) !important"
       },
       titleBar: {
         position: "relative",

--- a/client/js/components/main/attempts.jsx
+++ b/client/js/components/main/attempts.jsx
@@ -214,6 +214,7 @@ export default class Attempts extends BaseComponent {
     return {
       componentWrapper: {
         background: "#fff",
+        padding: "0 25px"
       },
       attemptsWrapper: {
         textAlign:"center"

--- a/client/js/components/main/attempts.jsx
+++ b/client/js/components/main/attempts.jsx
@@ -212,7 +212,9 @@ export default class Attempts extends BaseComponent {
 
   getStyles() {
     return {
-      componentWrapper: {},
+      componentWrapper: {
+        background: "#fff",
+      },
       attemptsWrapper: {
         textAlign:"center"
       },

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -184,7 +184,7 @@ export default class Start extends BaseComponent {
         height: theme.progressBarHeight
       },
       assessment: {
-        padding: 0,
+        padding: "0 25px",
         backgroundColor: theme.assessmentBackground,
         minWidth: minWidth
       },

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -84,8 +84,7 @@ export default class Start extends BaseComponent {
 
       ReviewAssessmentActions.loadAssessmentXmlForStudentReview(
         SettingsStore.current(),
-        SettingsStore.current().assessmentId,
-        SettingsStore.current().userAssessmentId
+        SettingsStore.current().assessmentId
       );
     }
 


### PR DESCRIPTION
This PR is the Release candidate branch for several small bug fixes:

1. Wait modal now renders in the center of the screen, regardless of how much the user scrolls up/down the page
2. When making the call to grab the Assessment XML to provide assessment result feedback, we no longer are passing a third argument that expects the Assessment Result Id.  Before, we were incorrectly passing the User Assessment Id, and it was decided that in the grand majority of cases, we don't need to know the assessment result id at all (with the caveat of 1 or 2 edge cases what will rarely crop up).
3. When embedded in LMS's like Blackboard, the style had the summative assessment start page content flush up against the side of the window, which didn't look great.  We've added the padding back in for better UX in other LMS's besides Canvas.