### PR TITLE
Assessment left/right padding

### DIFF
--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 <% else -%>
   <%= render partial: "assessments/assessment_setup" %>
-  <div id="assessment-container"></div>
+  <div id="assessment-container" style="width: 95%; margin: 0 auto;"></div>
   <%= webpack_manifest_script %>
   <%= webpack_bundle_tag 'app' %>
 <% end -%>


### PR DESCRIPTION
We need left and right padding for assessments because when we embed in some LMS's, it looks bad to not have it there.  So the decision was made to add it back in for better overall experience across all the LMS's we embed into (not just Canvas).