### PR TITLE
PROD-461: Self Checks and Feedback accessibility

### DIFF
--- a/app/views/default/take.html.erb
+++ b/app/views/default/take.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <%= render 'layouts/global/head' %>
   <%= stylesheet_link_tag "bare", media: "all" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <%= render 'layouts/global/head' %>
   <%= stylesheet_link_tag "application", media: "all" %>

--- a/app/views/layouts/assessment.html.erb
+++ b/app/views/layouts/assessment.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <%= render 'layouts/global/head' %>
     <%= stylesheet_link_tag "bare", media: "all" %>

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <%= render 'layouts/global/head' %>
     <%= stylesheet_link_tag "bare", media: "all" %>

--- a/app/views/user_mailer/contact_email.html.erb
+++ b/app/views/user_mailer/contact_email.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>

--- a/client/html/index.html
+++ b/client/html/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="">
+<html class="no-js" lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/client/js/components/assessment_results/formative_result.jsx
+++ b/client/js/components/assessment_results/formative_result.jsx
@@ -31,7 +31,7 @@ export default class FormativeResult extends React.Component {
             </header>
             <main role="main" style={styles.outcomeContainer}>
               <img style={resultFeedback.imageStyle} src={resultFeedback.imageSrc} role="presentation" />
-              <p style={styles.formativeResultHeader} tabIndex="0">
+              <p style={styles.formativeResultHeader} tabIndex="0" ref="resultHeader">
                 {resultFeedback.header}
               </p>
               <p style={styles.formativeResultFeedback} tabIndex="0">
@@ -59,6 +59,10 @@ export default class FormativeResult extends React.Component {
   componentDidMount() {
     CommHandler.sendSizeThrottled();
     CommHandler.showLMSNavigation();
+
+    if (this.refs.resultHeader) {
+      React.findDOMNode(this.refs.resultHeader).focus();
+    }
   }
 
   renderResultsTable(styles) {

--- a/client/js/components/assessment_results/formative_result.jsx
+++ b/client/js/components/assessment_results/formative_result.jsx
@@ -30,7 +30,7 @@ export default class FormativeResult extends React.Component {
               {this.getTitle()}
             </header>
             <main role="main" style={styles.outcomeContainer}>
-              <img style={resultFeedback.imageStyle} src={resultFeedback.imageSrc} />
+              <img style={resultFeedback.imageStyle} src={resultFeedback.imageSrc} role="presentation" />
               <p style={styles.formativeResultHeader} tabIndex="0">
                 {resultFeedback.header}
               </p>

--- a/client/js/components/assessment_results/formative_result.jsx
+++ b/client/js/components/assessment_results/formative_result.jsx
@@ -188,9 +188,7 @@ export default class FormativeResult extends React.Component {
           return dropdown.value === answerId;
         }).name;
 
-        return (
-          <strong>{chosenAnswerVal}</strong>
-        );
+        return `<strong>${chosenAnswerVal}</strong>`;
       });
     }
 

--- a/client/js/components/assessment_results/formative_result.jsx
+++ b/client/js/components/assessment_results/formative_result.jsx
@@ -31,9 +31,9 @@ export default class FormativeResult extends React.Component {
             </header>
             <main role="main" style={styles.outcomeContainer}>
               <img style={resultFeedback.imageStyle} src={resultFeedback.imageSrc} role="presentation" />
-              <p style={styles.formativeResultHeader} tabIndex="0" ref="resultHeader">
+              <h1 style={styles.formativeResultHeader} tabIndex="0" ref="resultHeader">
                 {resultFeedback.header}
-              </p>
+              </h1>
               <p style={styles.formativeResultFeedback} tabIndex="0">
                 {resultFeedback.feedback}
               </p>

--- a/client/js/components/assessment_results/formative_result.jsx
+++ b/client/js/components/assessment_results/formative_result.jsx
@@ -26,15 +26,15 @@ export default class FormativeResult extends React.Component {
       <div style={styles.assessment}>
         <div style={styles.assessmentContainer}>
           <div style={styles.outcomes}>
-            <div style={styles.header}>
+            <header role="banner" style={styles.header} tabIndex="0">
               {this.getTitle()}
-            </div>
-            <div style={styles.outcomeContainer}>
+            </header>
+            <main role="main" style={styles.outcomeContainer}>
               <img style={resultFeedback.imageStyle} src={resultFeedback.imageSrc} />
-              <p style={styles.formativeResultHeader}>
+              <p style={styles.formativeResultHeader} tabIndex="0">
                 {resultFeedback.header}
               </p>
-              <p style={styles.formativeResultFeedback}>
+              <p style={styles.formativeResultFeedback} tabIndex="0">
                 {resultFeedback.feedback}
               </p>
 
@@ -49,7 +49,7 @@ export default class FormativeResult extends React.Component {
                     Retake Quiz
                 </button>
               </div>
-            </div>
+            </main>
           </div>
         </div>
       </div>
@@ -71,11 +71,11 @@ export default class FormativeResult extends React.Component {
           <div key={"result-" + index}>
             <div style={styles.resultList}>
               <div>
-                <div style={{color: questionFeedback.color, ...styles.resultListInner}}>
+                <div style={{color: questionFeedback.color, ...styles.resultListInner}} tabIndex="0">
                   Question {index + 1} &mdash; {questionFeedback.message}
                 </div>
 
-                <div style={{color: confidenceFeedback, float: "right", marginTop: "20px"}}>
+                <div style={{color: confidenceFeedback, float: "right", marginTop: "20px"}} tabIndex="0">
                   {this.props.assessmentResult.confidence_level_list[parseInt(index)]}
                 </div>
               </div>
@@ -202,7 +202,7 @@ export default class FormativeResult extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div dangerouslySetInnerHTML={{__html: material}} />
+      <div dangerouslySetInnerHTML={{__html: material}} tabIndex="0" />
     );
   }
 

--- a/client/js/components/assessments/formativeHeader.jsx
+++ b/client/js/components/assessments/formativeHeader.jsx
@@ -10,11 +10,11 @@ export default class FormativeHeader extends BaseComponent {
     let styles = this.getStyles();
 
     return(
-      <div style={styles.header}>
+      <header role="banner" style={styles.header}>
         <h1 style={styles.h1} tabIndex="0">
           {this.props.assessmentTitle}
         </h1>
-      </div>
+      </header>
     );
   }
 

--- a/client/js/components/assessments/formativeHeader.jsx
+++ b/client/js/components/assessments/formativeHeader.jsx
@@ -11,7 +11,7 @@ export default class FormativeHeader extends BaseComponent {
 
     return(
       <div style={styles.header}>
-        <h1 style={styles.h1}>
+        <h1 style={styles.h1} tabIndex="0">
           {this.props.assessmentTitle}
         </h1>
       </div>

--- a/client/js/components/assessments/formativeHeader.jsx
+++ b/client/js/components/assessments/formativeHeader.jsx
@@ -11,9 +11,9 @@ export default class FormativeHeader extends BaseComponent {
 
     return(
       <header role="banner" style={styles.header}>
-        <h1 style={styles.h1} tabIndex="0">
+        <h2 style={styles.h1}>
           {this.props.assessmentTitle}
-        </h1>
+        </h2>
       </header>
     );
   }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -50,7 +50,7 @@ export default class Item extends BaseComponent {
                   <div aria-live="polite">
                     { this.newQuestionNotification(styles) }
                   </div>
-                  <h2 style={styles.visuallyHidden} ref="assessmenttext" tabIndex="-1">Assessment Text</h2>
+                  <h2 style={styles.visuallyHidden} tabIndex="-1">Assessment Text</h2>
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}} >
@@ -80,11 +80,6 @@ export default class Item extends BaseComponent {
     return this.props.answerMessage && AssessmentStore.isFormative();
   }
 
-  shouldFocusOnNewQuestion() {
-    // only focus if the assessment progress control is not available
-    return this.props.newQuestion && this.refs.assessmenttext && this.refs.assessmenttext.getDOMNode() && !document.getElementById("focus");
-  }
-
   shouldForceFeedbackFocus() {
     return this.state && this.state.forceFeedbackFocus && this.isSelfCheckResult();
   }
@@ -94,10 +89,7 @@ export default class Item extends BaseComponent {
   }
 
   componentDidUpdate() {
-    console.log("item component did update, state = ", this.state, " activeElement = ", document.activeElement);
-    if (this.shouldFocusOnNewQuestion()) {
-      this.refs.assessmenttext.getDOMNode().focus();
-    } else if (this.shouldForceFeedbackFocus()) {
+   if (this.shouldForceFeedbackFocus()) {
       if (this.hasFeedbackRef()) {
         // focus on the top component
         this.feedbackRef.getDOMNode().focus();
@@ -526,7 +518,7 @@ export default class Item extends BaseComponent {
   }
 
   newQuestionNotification(styles) {
-    if (this.props.newQuestion && AssessmentStore.isFormative()) {
+    if (this.props.newQuestion) {
       return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text heading.</div>);
     } else {
       return "";

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -83,7 +83,7 @@ export default class Item extends BaseComponent {
   getAriaLabel() {
     // if answerMessage isn't undefined, the question has been answered.
     if (typeof this.props.answerMessage !== "undefined") {
-      return "Confidence level selected. Feedback is presented below.";
+      return "Question feedback follows below.";
     } else {
       return "";
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -525,7 +525,7 @@ export default class Item extends BaseComponent {
   }
 
   newQuestionNotification(styles) {
-    if (this.props.newQuestion && !AssessmentStore.isSummative() && !AssessmentStore.isSwyk() && AssessmentStore.kind() !== "show_what_you_know") {
+    if (this.props.newQuestion && AssessmentStore.isFormative()) {
       return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text header.</div>);
     } else {
       return "";

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -54,8 +54,8 @@ export default class Item extends BaseComponent {
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
                     role="region"
-                    aria-labelledby="questionTextHeader">
-                      <div id="questionTextHeader" style={styles.visuallyHidden}>Question Text</div>
+                    aria-labelledby="assessmentTextHeader">
+                      <div id="assessmentTextHeader" style={styles.visuallyHidden}>Assessment Text</div>
                       {this.questionDirections(styles)}
                       {this.questionContent()}
                   </div>
@@ -68,6 +68,9 @@ export default class Item extends BaseComponent {
                   {this.submitAssessmentButton(styles)}
                   {this.getWarning(this.state, this.props.questionCount, this.props.currentIndex, styles)}
                   {this.mustAnswerMessage(styles)}
+                </div>
+                <div role="region" aria-labelledby="assessmentBottomBoundary" style={styles.visuallyHidden}>
+                  <div id="assessmentBottomBoundary">This is the bottom of the assessment area.</div>
                 </div>
               </div>
             </form>
@@ -491,7 +494,7 @@ export default class Item extends BaseComponent {
 
   newQuestionNotification(styles) {
     if (this.props.newQuestion) {
-      return (<div style={styles.visuallyHidden}>The question has been refreshed. Please navigate to the Question Text landmark.</div>);
+      return (<div style={styles.visuallyHidden}>The question has been refreshed. Please navigate to the Assessment Text landmark.</div>);
     } else {
       return "";
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -331,7 +331,7 @@ export default class Item extends BaseComponent {
     // if this is a multiple answer question
     if (this.props.question.question_type === "multiple_answers_question") {
       return (
-        <div style={styles.chooseText}>Select all correct answers</div>
+        <div style={styles.chooseText} tabIndex="0">Select all correct answers</div>
       );
     }
   }
@@ -350,7 +350,7 @@ export default class Item extends BaseComponent {
     */
     if (this.props.question.question_type !== 'multiple_dropdowns_question') {
       return (
-        <div dangerouslySetInnerHTML={{ __html: this.props.question.material }}></div>
+        <div dangerouslySetInnerHTML={{ __html: this.props.question.material }} tabIndex="0" />
       );
     }
   }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -78,8 +78,10 @@ export default class Item extends BaseComponent {
     this.focusQuestionContent();
   }
 
-  componentWillUpdate() {
-    this.focusQuestionContent();
+  componentWillUpdate(nProps) {
+    if (nProps.answerMessage !== this.props.answerMessage) {
+      this.focusQuestionContent();
+    }
   }
 
   getAriaLabel() {
@@ -218,7 +220,9 @@ export default class Item extends BaseComponent {
     if (this.props.question.confidenceLevel) {
       return (
         <div className="confidence_feedback_wrapper" style={styles.confidenceFeedbackWrapper}>
-          <p>Your confidence level in answering this question was: <strong>{`${this.props.question.confidenceLevel}`}</strong>.</p>
+          <p tabIndex="0">
+            Your confidence level in answering this question was: <strong>{`${this.props.question.confidenceLevel}`}</strong>.
+          </p>
           {this.getConfidenceNavButton(styles)}
         </div>
       );

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -94,6 +94,7 @@ export default class Item extends BaseComponent {
   }
 
   componentDidUpdate() {
+    console.log("item component did update, state = ", this.state, " activeElement = ", document.activeElement);
     if (this.shouldFocusOnNewQuestion()) {
       this.refs.assessmenttext.getDOMNode().focus();
     } else if (this.shouldForceFeedbackFocus()) {

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -41,15 +41,13 @@ export default class Item extends BaseComponent {
           <div style={styles.formativePadding}>
 
             <form className="edit_item">
-              <div className="full_question" style={styles.fullQuestion} aria-live="polite">
+              <div className="full_question" style={styles.fullQuestion}>
                 {this.formativeHeader()}
                 {this.simpleProgress(styles)}
                 <main
-                    role="main"
                     className="inner_question"
                     style={styles.innerQuestion}
-                    ref="questionMain"
-                    tabIndex="0">
+                    aria-atomic="true">
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
@@ -484,16 +482,6 @@ export default class Item extends BaseComponent {
             {this.props.currentIndex + 1} of {this.props.questionCount}
         </span>
       );
-    }
-  }
-
-  focusQuestion() {
-    React.findDOMNode(this.refs.questionText).focus();
-  }
-
-  componentHasUpdated(prevProps) {
-    if (prevProps.newQuestion) {
-      this.focusQuestion();
     }
   }
 

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -76,12 +76,17 @@ export default class Item extends BaseComponent {
     );
   }
 
+  isSelfCheckResult() {
+    return this.props.answerMessage && !AssessmentStore.isSummative() && !AssessmentStore.isSwyk();
+  }
+
   shouldFocusOnNewQuestion() {
-    return this.props.newQuestion && this.refs.assessmenttext && this.refs.assessmenttext.getDOMNode();
+    // only focus if the assessment progress control is not available
+    return this.props.newQuestion && this.refs.assessmenttext && this.refs.assessmenttext.getDOMNode() && !document.getElementById("focus");
   }
 
   shouldForceFeedbackFocus() {
-    return this.state && this.state.forceFeedbackFocus;
+    return this.state && this.state.forceFeedbackFocus && this.isSelfCheckResult();
   }
 
   hasFeedbackRef() {
@@ -398,7 +403,7 @@ export default class Item extends BaseComponent {
   }
 
   inputOrReview(styles) {
-    if (!this.props.answerMessage || (AssessmentStore.isSummative() || AssessmentStore.isSwyk())) {
+    if (!this.isSelfCheckResult()) {
       return (
         <UniversalInput
           item={this.props.question}
@@ -520,7 +525,7 @@ export default class Item extends BaseComponent {
   }
 
   newQuestionNotification(styles) {
-    if (this.props.newQuestion) {
+    if (this.props.newQuestion && !AssessmentStore.isSummative() && !AssessmentStore.isSwyk() && AssessmentStore.kind() !== "show_what_you_know") {
       return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text header.</div>);
     } else {
       return "";

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -74,10 +74,6 @@ export default class Item extends BaseComponent {
     );
   }
 
-  componentDidMount() {
-    this.focusQuestionContent();
-  }
-
   componentWillUpdate(nProps) {
     if (nProps.answerMessage !== this.props.answerMessage) {
       this.focusQuestionContent();

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -339,7 +339,14 @@ export default class Item extends BaseComponent {
     // if this is a multiple answer question
     if (this.props.question.question_type === "multiple_answers_question") {
       return (
-        <div style={styles.chooseText} tabIndex="0">Select all correct answers</div>
+        <div style={styles.chooseText} tabIndex="0" ref="questionContent">Select all correct answers</div>
+      );
+    }
+
+    // if this is a multiple dropdown question
+    if (this.props.question.question_type === "multiple_dropdowns_question") {
+      return (
+        <div style={styles.chooseText} tabIndex="0" ref="questionContent">Choose the best answer in each dropdown</div>
       );
     }
   }
@@ -369,7 +376,9 @@ export default class Item extends BaseComponent {
   }
 
   focusQuestionContent() {
-    React.findDOMNode(this.refs.questionContent).focus();
+    if (this.refs.questionContent) {
+      React.findDOMNode(this.refs.questionContent).focus();
+    }
   }
 
   inputOrReview(styles) {

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -48,6 +48,8 @@ export default class Item extends BaseComponent {
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
+                    tabIndex="0"
+                    ref="questionContent"
                     >
                       {this.questionDirections(styles)}
                       {this.questionContent()}
@@ -339,14 +341,14 @@ export default class Item extends BaseComponent {
     // if this is a multiple answer question
     if (this.props.question.question_type === "multiple_answers_question") {
       return (
-        <div style={styles.chooseText} tabIndex="0" ref="questionContent">Select all correct answers</div>
+        <div style={styles.chooseText}>Select all correct answers</div>
       );
     }
 
     // if this is a multiple dropdown question
     if (this.props.question.question_type === "multiple_dropdowns_question") {
       return (
-        <div style={styles.chooseText} tabIndex="0" ref="questionContent">Choose the best answer in each dropdown</div>
+        <div style={styles.chooseText}>Choose the best answer in each dropdown</div>
       );
     }
   }
@@ -367,9 +369,7 @@ export default class Item extends BaseComponent {
       return (
         <div
           id="question-content"
-          ref="questionContent"
           dangerouslySetInnerHTML={{ __html: this.props.question.material }}
-          tabIndex="0"
           />
       );
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -46,9 +46,7 @@ export default class Item extends BaseComponent {
                 {this.simpleProgress(styles)}
                 <main
                     className="inner_question"
-                    style={styles.innerQuestion}
-                    aria-atomic="true"
-                    aria-relevant="additions text">
+                    style={styles.innerQuestion}>
                   <div aria-live="polite">
                     { this.newQuestionNotification(styles) }
                   </div>
@@ -493,7 +491,7 @@ export default class Item extends BaseComponent {
 
   newQuestionNotification(styles) {
     if (this.props.newQuestion) {
-      return (<div style={styles.visuallyHidden}>The question has been refreshed.</div>);
+      return (<div style={styles.visuallyHidden}>The question has been refreshed. Please navigate to the Question Text landmark.</div>);
     } else {
       return "";
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -48,7 +48,6 @@ export default class Item extends BaseComponent {
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
-                    aria-label={this.getAriaLabel()}
                     >
                       {this.questionDirections(styles)}
                       {this.questionContent()}
@@ -70,15 +69,6 @@ export default class Item extends BaseComponent {
         </div>
       </div>
     );
-  }
-
-  getAriaLabel() {
-    // if answerMessage isn't undefined, the question has been answered.
-    if (typeof this.props.answerMessage !== "undefined") {
-      return "Question feedback follows below.";
-    } else {
-      return "";
-    }
   }
 
   mustAnswerMessage(styles) {

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -519,7 +519,9 @@ export default class Item extends BaseComponent {
 
   newQuestionNotification(styles) {
     if (this.props.newQuestion) {
-      return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text heading.</div>);
+      const currQuestion = this.props.currentIndex + 1;
+      const message = `New question is available. You are on question ${currQuestion} of ${this.props.questionCount}. Navigate to the assement text heading to read the question.`;
+      return (<div style={styles.visuallyHidden}>{message}</div>);
     } else {
       return "";
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -48,7 +48,6 @@ export default class Item extends BaseComponent {
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
-                    ref="questionContent"
                     aria-label={this.getAriaLabel()}
                     >
                       {this.questionDirections(styles)}
@@ -71,12 +70,6 @@ export default class Item extends BaseComponent {
         </div>
       </div>
     );
-  }
-
-  componentWillUpdate(nProps) {
-    if (nProps.answerMessage !== this.props.answerMessage) {
-      this.focusQuestionContent();
-    }
   }
 
   getAriaLabel() {
@@ -129,7 +122,6 @@ export default class Item extends BaseComponent {
         if (that.props.currentIndex === that.props.questionCount - 1 &&
             AssessmentStore.isFormative()) {
           that.props.checkAnswer(that.props.currentIndex);
-          this.focusQuestionContent();
         // otherwise, this is not the last question and/or it's not formative
         } else {
           that.clearShowMessage();
@@ -382,12 +374,6 @@ export default class Item extends BaseComponent {
           dangerouslySetInnerHTML={{ __html: this.props.question.material }}
           />
       );
-    }
-  }
-
-  focusQuestionContent() {
-    if (this.refs.questionContent) {
-      React.findDOMNode(this.refs.questionContent).focus();
     }
   }
 

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -41,10 +41,13 @@ export default class Item extends BaseComponent {
           <div style={styles.formativePadding}>
 
             <form className="edit_item">
-              <div className="full_question" style={styles.fullQuestion}>
+              <div className="full_question" style={styles.fullQuestion} aria-live="polite">
                 {this.formativeHeader()}
                 {this.simpleProgress(styles)}
-                <main role="main" className="inner_question" style={styles.innerQuestion}>
+                <main
+                    role="main"
+                    className="inner_question"
+                    style={styles.innerQuestion}>
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -77,7 +77,7 @@ export default class Item extends BaseComponent {
   }
 
   isSelfCheckResult() {
-    return this.props.answerMessage && !AssessmentStore.isSummative() && !AssessmentStore.isSwyk();
+    return this.props.answerMessage && AssessmentStore.isFormative();
   }
 
   shouldFocusOnNewQuestion() {
@@ -526,7 +526,7 @@ export default class Item extends BaseComponent {
 
   newQuestionNotification(styles) {
     if (this.props.newQuestion && AssessmentStore.isFormative()) {
-      return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text header.</div>);
+      return (<div style={styles.visuallyHidden}>The question has been refreshed. The refreshed material is just after the Assessment Text heading.</div>);
     } else {
       return "";
     }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -47,7 +47,9 @@ export default class Item extends BaseComponent {
                 <main
                     role="main"
                     className="inner_question"
-                    style={styles.innerQuestion}>
+                    style={styles.innerQuestion}
+                    ref="questionMain"
+                    tabIndex="0">
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
@@ -482,6 +484,16 @@ export default class Item extends BaseComponent {
             {this.props.currentIndex + 1} of {this.props.questionCount}
         </span>
       );
+    }
+  }
+
+  focusQuestion() {
+    React.findDOMNode(this.refs.questionText).focus();
+  }
+
+  componentHasUpdated(prevProps) {
+    if (prevProps.newQuestion) {
+      this.focusQuestion();
     }
   }
 

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -48,7 +48,6 @@ export default class Item extends BaseComponent {
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
-                    tabIndex="0"
                     ref="questionContent"
                     aria-label={this.getAriaLabel()}
                     >
@@ -217,7 +216,7 @@ export default class Item extends BaseComponent {
     if (this.props.question.confidenceLevel) {
       return (
         <div className="confidence_feedback_wrapper" style={styles.confidenceFeedbackWrapper}>
-          <p tabIndex="0">
+          <p>
             Your confidence level in answering this question was: <strong>{`${this.props.question.confidenceLevel}`}</strong>.
           </p>
           {this.getConfidenceNavButton(styles)}
@@ -229,7 +228,7 @@ export default class Item extends BaseComponent {
     if (AssessmentStore.isFormative()) {
       return (
         <div className="confidence_wrapper" style={styles.confidenceWrapper}>
-          <div tabIndex="0" style={styles.confidenceTitle}>
+          <div style={styles.confidenceTitle}>
             How sure are you of your answer?
           </div>
           <input

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -47,7 +47,8 @@ export default class Item extends BaseComponent {
                 <main
                     className="inner_question"
                     style={styles.innerQuestion}
-                    aria-atomic="true">
+                    aria-atomic="true"
+                    aria-relevant="additions text">
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -71,6 +71,14 @@ export default class Item extends BaseComponent {
     );
   }
 
+  componentDidMount() {
+    this.focusQuestionContent();
+  }
+
+  componentWillUpdate() {
+    this.focusQuestionContent();
+  }
+
   mustAnswerMessage(styles) {
     if (this.state && this.state.showMessage) {
       return (
@@ -350,9 +358,18 @@ export default class Item extends BaseComponent {
     */
     if (this.props.question.question_type !== 'multiple_dropdowns_question') {
       return (
-        <div dangerouslySetInnerHTML={{ __html: this.props.question.material }} tabIndex="0" />
+        <div
+          id="question-content"
+          ref="questionContent"
+          dangerouslySetInnerHTML={{ __html: this.props.question.material }}
+          tabIndex="0"
+          />
       );
     }
+  }
+
+  focusQuestionContent() {
+    React.findDOMNode(this.refs.questionContent).focus();
   }
 
   inputOrReview(styles) {

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -49,10 +49,15 @@ export default class Item extends BaseComponent {
                     style={styles.innerQuestion}
                     aria-atomic="true"
                     aria-relevant="additions text">
+                  <div aria-live="polite">
+                    { this.newQuestionNotification(styles) }
+                  </div>
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
-                    >
+                    role="region"
+                    aria-labelledby="questionTextHeader">
+                      <div id="questionTextHeader" style={styles.visuallyHidden}>Question Text</div>
                       {this.questionDirections(styles)}
                       {this.questionContent()}
                   </div>
@@ -486,6 +491,14 @@ export default class Item extends BaseComponent {
     }
   }
 
+  newQuestionNotification(styles) {
+    if (this.props.newQuestion) {
+      return (<div style={styles.visuallyHidden}>The question has been refreshed.</div>);
+    } else {
+      return "";
+    }
+  }
+
   getStyles(theme) {
     let navMargin = "-35px 650px 0 0";
 
@@ -656,6 +669,16 @@ export default class Item extends BaseComponent {
       counter: {
         color: 'black',
         float: "right"
+      },
+      visuallyHidden: {
+        position: "absolute !important",
+        left: "-10000px",
+        top: "auto",
+        width: "1px",
+        height: "1px",
+        overflow: "hidden",
+        clip: "rect(1px, 1px, 1px, 1px)",
+        whiteSpace: "nowrap"
       }
     }
   }

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -44,7 +44,7 @@ export default class Item extends BaseComponent {
               <div className="full_question" style={styles.fullQuestion}>
                 {this.formativeHeader()}
                 {this.simpleProgress(styles)}
-                <div className="inner_question" style={styles.innerQuestion}>
+                <main role="main" className="inner_question" style={styles.innerQuestion}>
                   <div
                     className="question_text"
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
@@ -53,7 +53,7 @@ export default class Item extends BaseComponent {
                       {this.questionContent()}
                   </div>
                   {this.inputOrReview(styles)}
-                </div>
+                </main>
                 <div>
                   {this.getConfidenceLevels(this.props.confidenceLevels, styles)}
                   {this.checkAnswerButton(styles)}

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -134,6 +134,7 @@ export default class Item extends BaseComponent {
         if (that.props.currentIndex === that.props.questionCount - 1 &&
             AssessmentStore.isFormative()) {
           that.props.checkAnswer(that.props.currentIndex);
+          this.focusQuestionContent();
         // otherwise, this is not the last question and/or it's not formative
         } else {
           that.clearShowMessage();

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -50,6 +50,7 @@ export default class Item extends BaseComponent {
                     style={this.props.question.question_type !== "multiple_dropdowns_question" ? styles.questionText : {}}
                     tabIndex="0"
                     ref="questionContent"
+                    aria-label={this.getAriaLabel()}
                     >
                       {this.questionDirections(styles)}
                       {this.questionContent()}
@@ -79,6 +80,15 @@ export default class Item extends BaseComponent {
 
   componentWillUpdate() {
     this.focusQuestionContent();
+  }
+
+  getAriaLabel() {
+    // if answerMessage isn't undefined, the question has been answered.
+    if (typeof this.props.answerMessage !== "undefined") {
+      return "Confidence level selected. Feedback is presented below.";
+    } else {
+      return "";
+    }
   }
 
   mustAnswerMessage(styles) {

--- a/client/js/components/assessments/item.jsx
+++ b/client/js/components/assessments/item.jsx
@@ -76,12 +76,23 @@ export default class Item extends BaseComponent {
     );
   }
 
+  shouldFocusOnNewQuestion() {
+    return this.props.newQuestion && this.refs.assessmenttext && this.refs.assessmenttext.getDOMNode();
+  }
+
+  shouldForceFeedbackFocus() {
+    return this.state && this.state.forceFeedbackFocus;
+  }
+
+  hasFeedbackRef() {
+    return this.feedbackRef && this.feedbackRef.getDOMNode();
+  }
+
   componentDidUpdate() {
-    if (this.props.newQuestion && this.refs.assessmenttext && this.refs.assessmenttext.getDOMNode()) {
+    if (this.shouldFocusOnNewQuestion()) {
       this.refs.assessmenttext.getDOMNode().focus();
-    }
-    if (this.state && this.state.forceFeedbackFocus) {
-      if (this.feedbackRef && this.feedbackRef.getDOMNode()) {
+    } else if (this.shouldForceFeedbackFocus()) {
+      if (this.hasFeedbackRef()) {
         // focus on the top component
         this.feedbackRef.getDOMNode().focus();
       }

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -121,9 +121,9 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  renderDefaultReviewPrompt(styles) {
+  renderDefaultReviewPrompt() {
     if (this.props.isResult) {
-      return (<div style={styles.visuallyHidden}>Your selection has been evaluated.</div>);
+      return (<div>Your selection has been evaluated.</div>);
     } else {
       return "";
     }
@@ -149,11 +149,11 @@ export default class UniversalInput extends React.Component{
       case "multiple_choice_question":
       case "true_false_question":
         items = this.renderMultipleChoiceQuestion(item, styles);
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleChoiceQuestion(item, styles);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleChoiceQuestion(item);
         break;
       case "matching_question":
         items = <Matching assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult}  item={item} name="answer-option"/>;
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
         break;
       case "essay_question":
         items = <TextArea assessmentKind={this.props.assessmentKind} completed={this.props.completed} isDisabled={this.props.isResult} key="textarea_essay_input" item={item} initialText={this.props.chosen} />;
@@ -161,15 +161,15 @@ export default class UniversalInput extends React.Component{
         break;
       case "multiple_answers_question":
         items = this.renderMultipleAnswersQuestion(item, styles);
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleAnswersQuestion(item, styles);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleAnswersQuestion(item);
         break;
       case "mom_embed":
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
         break;
       case 'multiple_dropdowns_question':
         items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} shouldFocusForFeedback={this.props.shouldFocusForFeedback} />;
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultiDropDownQuestion(item, this.props.chosen, styles);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultiDropDownQuestion(item, this.props.chosen);
       break;
     }
 
@@ -237,7 +237,7 @@ export default class UniversalInput extends React.Component{
     return (<div>The question has been evaluated. Your choice is partially correct.</div>);
   }
 
-  renderReviewPromptForMultipleChoiceQuestion(item, styles) {
+  renderReviewPromptForMultipleChoiceQuestion(item) {
     if (this.props.isResult) {
       const chosenAnswers = item.answers.filter((answer) => {
         return this.wasChosen(answer.id);
@@ -318,20 +318,25 @@ export default class UniversalInput extends React.Component{
     }, 0);
   }
 
-  renderReviewPromptForMultipleAnswersQuestion(item, styles) {
-    if (this.props.isResult) {
-      const totalToCheck = this.determineMultiAnswerTotals(item);
-      const correctCount = this.determineMultiAnswerCorrectCount(item);
-      const incorrectCount = this.determineMultiAnswerIncorrectCount(item);
-      if (correctCount === 0 ) {
-        return this.renderIncorrectResponsePrompt();
-      } else if (correctCount < totalToCheck || incorrectCount > 0) {
-        return this.renderPartiallyCorrectResponsePrompt();
-      } else {
-        return this.renderCorrectResponsePrompt();
-      }
+  choosePromptForMultipleAnswerQuestion(item) {
+    const totalToCheck = this.determineMultiAnswerTotals(item);
+    const correctCount = this.determineMultiAnswerCorrectCount(item);
+    const incorrectCount = this.determineMultiAnswerIncorrectCount(item);
+    if (correctCount === 0 ) {
+      return this.renderIncorrectResponsePrompt();
+    } else if (correctCount < totalToCheck || incorrectCount > 0) {
+      return this.renderPartiallyCorrectResponsePrompt();
+    } else {
+      return this.renderCorrectResponsePrompt();
     }
-    return null;
+  }
+
+  renderReviewPromptForMultipleAnswersQuestion(item) {
+    if (this.props.isResult) {
+      return this.choosePromptForMultipleAnswerQuestion(item);
+    } else {
+      return null;
+    }
   }
 
   isDropdownAnswerCorrect(currChosenAnswer, i) {
@@ -358,7 +363,7 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  renderReviewPromptForMultiDropDownQuestion(item, chosenAnswers, styles) {
+  renderReviewPromptForMultiDropDownQuestion(item, chosenAnswers) {
     if (this.props.isResult && chosenAnswers && chosenAnswers.length > 0) {
       return this.determineDropdownCorrectMessage(item, chosenAnswers);
     }

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -274,21 +274,29 @@ export default class UniversalInput extends React.Component{
     );
   }
 
-  renderMultiAnswerCorrectSummary(item) {
-    const totalToCheck = (this.props.correctAnswers && this.props.correctAnswers[0])
+  determineMultiAnswerTotals(item) {
+    return (this.props.correctAnswers && this.props.correctAnswers[0])
       ? this.props.correctAnswers[0].id.length
       : -1;
-    const correctCount = item.answers.reduce((sum, answer) => {
+  }
+
+  determineMultiAnswerCorrectCount(item) {
+    return item.answers.reduce((sum, answer) => {
       if (this.showAsCorrect(answer.id) && this.wasChosen(answer.id)) {
         return sum + 1;
       } else {
         return sum;
       }
     }, 0);
+  }
+
+  renderMultiAnswerCorrectSummary(item) {
+    const totalToCheck = this.determineMultiAnswerTotals(item);
+    const correctCount = this.determineMultiAnswerCorrectCount(item);
     if (correctCount === 0 ) {
       return "Question answer incorrect. ";
     } else if (correctCount < totalToCheck) {
-      return "Question answer partially correct. "
+      return "Question answer partially correct. ";
     } else {
       return "Question answer correct. ";
     }
@@ -305,8 +313,15 @@ export default class UniversalInput extends React.Component{
         return " Incorrectly chosen. ";
       }
     } else if (isCorrect) {
-      return " Incorrectly not chosen. "
+      return " Incorrectly not chosen. ";
     }
+  }
+
+  buildMultiAnswerRenderableFeedback(answer) {
+    const feedback = this.answerFeedback(answer.id);
+    return (feedback && feedback.length > 0)
+      ? (<div>Feedback: <span dangerouslySetInnerHTML={ { __html: feedback } }/></div>)
+      : "";
   }
 
   renderReviewPromptForMultipleAnswersQuestion(item) {
@@ -315,13 +330,9 @@ export default class UniversalInput extends React.Component{
       const prompts = item.answers.
         map((answer, index) => {
           if (this.wasChosen(answer.id) || this.showAsCorrect(answer.id)) {
-            const feedback = this.answerFeedback(answer.id);
-
             const prefix = `Item ${index + 1} `;
             const correctFeedback = this.renderMultiAnswerCorrectFeedback(answer);
-            const renderableFeedback = (feedback && feedback.length > 0)
-              ? (<div>Feedback: <span dangerouslySetInnerHTML={ { __html: feedback } }/></div>)
-              : "";
+            const renderableFeedback = this.buildMultiAnswerRenderableFeedback(answer);
             const material = answer.material;
 
             return (<div>

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -48,15 +48,15 @@ export default class UniversalInput extends React.Component{
         padding: theme.panelBodyPadding,
         marginTop: "-20px",
       },
-      legend: {
-        position: "absolute !important",
+      visuallyHidden: {
+        //position: "absolute !important",
         //left: "-10000px",
-        top: "auto",
-        width: "1px",
-        height: "1px",
-        overflow: "hidden",
-        clip: "rect(1px, 1px, 1px, 1px)",
-        whiteSpace: "nowrap"
+        //top: "auto",
+        //width: "1px",
+        //height: "1px",
+        //overflow: "hidden",
+        //clip: "rect(1px, 1px, 1px, 1px)",
+        //whiteSpace: "nowrap"
       }
     }
   }
@@ -114,14 +114,18 @@ export default class UniversalInput extends React.Component{
      *
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
-    if(item.isGraded && item.solution){
+    if (item.isGraded && item.solution) {
       solution = (<div className="panel-footer text-center">
-                  <div
-                    dangerouslySetInnerHTML={{
-                      __html: item.solution
-                    }}>
-                  </div>
-                 </div>);
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: item.solution
+                  }}>
+                </div>
+               </div>);
+    } else if (this.props.isResult) {
+      solution = (<div style={styles.visuallyHidden}>
+          Your selection has been graded.  Please navigate backwards to receive feedback.
+        </div>);
     }
 
     switch(item.question_type){
@@ -157,7 +161,9 @@ export default class UniversalInput extends React.Component{
           >
           { items }
         </div>
-        { solution }
+        <div aria-live="polite">
+          { solution }
+        </div>
       </div>
     );
   }
@@ -169,6 +175,7 @@ export default class UniversalInput extends React.Component{
           assessmentKind={this.props.assessmentKind}
           isDisabled={this.props.isResult}
           key={item.id + "_" + answer.id}
+          id={item.id + "_" + answer.id}
           item={answer}
           name="answer-radio"
           checked={this.wasChosen(answer.id)}
@@ -179,8 +186,8 @@ export default class UniversalInput extends React.Component{
     });
 
     return (
-      <fieldset tabIndex={-1}>
-        <legend style={styles.legend} tabIndex={-1}>Multiple Choice Question</legend>
+      <fieldset>
+        <legend style={styles.visuallyHidden}>Multiple Choice Question</legend>
         { answers }
       </fieldset>
     );
@@ -202,8 +209,8 @@ export default class UniversalInput extends React.Component{
     });
 
     return (
-      <fieldset tabIndex={-1}>
-        <legend style={styles.legend} tabIndex={-1}>Select all correct answers</legend>
+      <fieldset>
+        <legend style={styles.visuallyHidden}>Select all correct answers</legend>
         { answers }
       </fieldset>
     );

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -49,12 +49,14 @@ export default class UniversalInput extends React.Component{
         marginTop: "-20px",
       },
       legend: {
-        position: "absolute",
-        left: "-10000px",
+        position: "absolute !important",
+        //left: "-10000px",
         top: "auto",
         width: "1px",
         height: "1px",
-        overflow: "hidden"
+        overflow: "hidden",
+        clip: "rect(1px, 1px, 1px, 1px)",
+        whiteSpace: "nowrap"
       }
     }
   }

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -149,7 +149,8 @@ export default class UniversalInput extends React.Component{
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
         break;
       case 'multiple_dropdowns_question':
-        items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} visuallyHiddenStyle={styles.visuallyHidden} />;
+        items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} />;
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultiDropDownQuestion(item, this.props.chosen);
       break;
     }
 
@@ -247,6 +248,36 @@ export default class UniversalInput extends React.Component{
         { answers }
       </fieldset>
     );
+  }
+
+  renderReviewPromptForMultiDropDownQuestion(item, chosenAnswers) {
+    if (this.props.isResult && chosenAnswers && chosenAnswers.length > 0) {
+        let correctCount = 0;
+        const dropdownFeedbacks = chosenAnswers.map((ca, i) => {
+          const dropDownChoices = item.dropdowns[ca.dropdown_id];
+          const answerInfo = dropDownChoices.find((choice) => choice.value === ca.chosen_answer_id);
+
+          if (!answerInfo) {
+            return null;
+          } else {
+            if (answerInfo.isCorrect) {
+              correctCount += 1;
+            }
+            const feedback = (answerInfo.feedback) ? ` Feedback: ${answerInfo.feedback}` : "";
+            return `Selection ${i + 1} - ${answerInfo.name} - ${answerInfo.isCorrect ? " correct" : " incorrect"}.${feedback}`;
+          }
+        });
+        let summaryMessage = "Question answer correct.";
+        if (correctCount === 0) {
+          summaryMessage = "Question answer incorrect.";
+        } else if (correctCount < Object.keys(item.dropdowns).length) {
+          summaryMessage = "Question answer partially correct.";
+        }
+        const feedback = `${summaryMessage} You selected: ${dropdownFeedbacks.filter((msg) => msg !==  null).join("\n")}`;
+        return (<div dangerouslySetInnerHTML={ { __html: feedback } }/>);
+  } else {
+      return null;
+    }
   }
 }
 

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -90,6 +90,7 @@ export default class UniversalInput extends React.Component{
     let item = this.props.item;
     let messages = "";
     let solution = "";
+    let visuallyHiddenReviewPrompt = "";
     let items = "";
 
     if(item.messages){
@@ -122,10 +123,11 @@ export default class UniversalInput extends React.Component{
                   }}>
                 </div>
                </div>);
-    } else if (this.props.isResult) {
-      solution = (<div style={styles.visuallyHidden}>
-          Your selection has been graded.  Please navigate backwards to receive feedback.
-        </div>);
+    }
+    if (this.props.isResult) {
+      visuallyHiddenReviewPrompt = (<div style={styles.visuallyHidden}>
+        Your selection has been graded.  Please navigate forward to review your answers and receive feedback.
+      </div>);
     }
 
     switch(item.question_type){
@@ -155,13 +157,16 @@ export default class UniversalInput extends React.Component{
         <div className="panel-heading text-center" style={styles.panelHeading}>
           { messages }
         </div>
+        <div aria-live="polite">
+          { visuallyHiddenReviewPrompt }
+        </div>
         <div
           className={item.question_type === "multiple_dropdowns_question" ? "" : "panel-body"}
           style={styles.panelBody}
           >
           { items }
         </div>
-        <div aria-live="polite">
+        <div>
           { solution }
         </div>
       </div>

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -200,6 +200,7 @@ export default class UniversalInput extends React.Component{
           assessmentKind={this.props.assessmentKind}
           isDisabled={this.props.isResult}
           key={item.id + "_" + answer.id}
+          id={item.id + "_" + answer.id}
           item={answer} name="answer-check"
           checked={this.wasChosen(answer.id)}
           showAsCorrect={this.showAsCorrect(answer.id)}

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -2,15 +2,12 @@
 
 import React                from "react";
 import RadioButton          from "../common/radio_button";
-import Option               from "../common/option";
-import TextField            from "../common/text_field";
 import TextArea             from "../common/text_area";
 import CheckBox             from "../common/checkbox";
 import Matching             from "../common/matching";
 import MomEmbed             from "../common/mom_embed";
 import MultiDropDown        from '../common/multi_drop_down'
 import CommunicationHandler from "../../utils/communication_handler";
-import AssessmentStore      from "../../stores/assessment";
 
 export default class UniversalInput extends React.Component{
 

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -149,7 +149,7 @@ export default class UniversalInput extends React.Component{
       case "multiple_choice_question":
       case "true_false_question":
         items = this.renderMultipleChoiceQuestion(item, styles);
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleChoiceQuestion(item);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleChoiceQuestion(item, styles);
         break;
       case "matching_question":
         items = <Matching assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult}  item={item} name="answer-option"/>;
@@ -161,7 +161,7 @@ export default class UniversalInput extends React.Component{
         break;
       case "multiple_answers_question":
         items = this.renderMultipleAnswersQuestion(item, styles);
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleAnswersQuestion(item);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleAnswersQuestion(item, styles);
         break;
       case "mom_embed":
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
@@ -169,7 +169,7 @@ export default class UniversalInput extends React.Component{
         break;
       case 'multiple_dropdowns_question':
         items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} shouldFocusForFeedback={this.props.shouldFocusForFeedback} />;
-        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultiDropDownQuestion(item, this.props.chosen);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultiDropDownQuestion(item, this.props.chosen, styles);
       break;
     }
 
@@ -237,7 +237,7 @@ export default class UniversalInput extends React.Component{
     return (<div>The question has been evaluated. Your choice is partially correct.</div>);
   }
 
-  renderReviewPromptForMultipleChoiceQuestion(item) {
+  renderReviewPromptForMultipleChoiceQuestion(item, styles) {
     if (this.props.isResult) {
       const chosenAnswers = item.answers.filter((answer) => {
         return this.wasChosen(answer.id);
@@ -249,12 +249,9 @@ export default class UniversalInput extends React.Component{
         } else {
           return this.renderIncorrectResponsePrompt();
         }
-      } else {
-        return null;
       }
-    } else {
-      return null;
     }
+    return null;
   }
 
   doesCheckboxHaveFeedback(answerId) {
@@ -321,17 +318,20 @@ export default class UniversalInput extends React.Component{
     }, 0);
   }
 
-  renderReviewPromptForMultipleAnswersQuestion(item) {
-    const totalToCheck = this.determineMultiAnswerTotals(item);
-    const correctCount = this.determineMultiAnswerCorrectCount(item);
-    const incorrectCount = this.determineMultiAnswerIncorrectCount(item);
-    if (correctCount === 0 ) {
-      return this.renderIncorrectResponsePrompt();
-    } else if (correctCount < totalToCheck || incorrectCount > 0) {
-      return this.renderPartiallyCorrectResponsePrompt();
-    } else {
-      return this.renderCorrectResponsePrompt();
+  renderReviewPromptForMultipleAnswersQuestion(item, styles) {
+    if (this.props.isResult) {
+      const totalToCheck = this.determineMultiAnswerTotals(item);
+      const correctCount = this.determineMultiAnswerCorrectCount(item);
+      const incorrectCount = this.determineMultiAnswerIncorrectCount(item);
+      if (correctCount === 0 ) {
+        return this.renderIncorrectResponsePrompt();
+      } else if (correctCount < totalToCheck || incorrectCount > 0) {
+        return this.renderPartiallyCorrectResponsePrompt();
+      } else {
+        return this.renderCorrectResponsePrompt();
+      }
     }
+    return null;
   }
 
   isDropdownAnswerCorrect(currChosenAnswer, i) {
@@ -358,12 +358,11 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  renderReviewPromptForMultiDropDownQuestion(item, chosenAnswers) {
+  renderReviewPromptForMultiDropDownQuestion(item, chosenAnswers, styles) {
     if (this.props.isResult && chosenAnswers && chosenAnswers.length > 0) {
       return this.determineDropdownCorrectMessage(item, chosenAnswers);
-    } else {
-      return null;
     }
+    return null;
   }
 }
 

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -187,8 +187,6 @@ export default class UniversalInput extends React.Component{
           checked={this.wasChosen(answer.id)}
           showAsCorrect={this.showAsCorrect(answer.id)}
           answerFeedback={this.answerFeedback(answer.id)}
-          index={index}
-          visuallyHiddenStyle={styles.visuallyHidden}
           />
       );
     });
@@ -209,10 +207,11 @@ export default class UniversalInput extends React.Component{
       if (chosenAnswers.length > 0) {
         const chosenAnswer = chosenAnswers[0];
         const isCorrectMessage = (this.showAsCorrect(chosenAnswer.id))
-          ? "Your choice is correct."
-          : "Your choice is incorrect.";
+          ? "correct"
+          : "incorrect";
         return (<div>
-          { isCorrectMessage }
+          The question has been evaluated.  Your choice is { isCorrectMessage }.  You selected:
+          <div dangerouslySetInnerHTML={ { __html: chosenAnswer.material } }/> .
           <div dangerouslySetInnerHTML={ { __html: this.answerFeedback(chosenAnswer.id) } }/>
         </div>);
         return null;

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -178,8 +178,8 @@ export default class UniversalInput extends React.Component{
     });
 
     return (
-      <fieldset>
-        <legend style={styles.legend}>Select all correct answers</legend>
+      <fieldset tabIndex={-1}>
+        <legend style={styles.legend} tabIndex={-1}>Select all correct answers</legend>
         { answers }
       </fieldset>
     );

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -257,10 +257,14 @@ export default class UniversalInput extends React.Component{
     }
   }
 
+  doesCheckboxHaveFeedback(answerId) {
+    return this.props.isResult && (this.wasChosen(answerId) || this.answerFeedback(answerId));
+  }
+
   renderMultipleAnswersQuestion(item, styles) {
     let refAdded = false;
     let answers = item.answers.map((answer, index) => {
-      const showsFeedback = (!refAdded && this.props.isResult && (this.wasChosen(answer.id) || this.answerFeedback(answer.id)));
+      const showsFeedback = !refAdded && this.doesCheckboxHaveFeedback(answer.id);
       if (showsFeedback) {
         refAdded = true;
       }
@@ -319,12 +323,16 @@ export default class UniversalInput extends React.Component{
     }
   }
 
+  isDropdownAnswerCorrect(currChosenAnswer, i) {
+    return (currChosenAnswer.chosen_answer_id &&
+      this.props.correctAnswers[i] &&
+      this.props.correctAnswers[i].value &&
+      currChosenAnswer.chosen_answer_id === this.props.correctAnswers[i].value);
+  }
+
   determineDropdownCorrectMessage(item, chosenAnswers) {
     const correctCount = chosenAnswers.reduce((sum, currChosenAnswer, i) => {
-      if (currChosenAnswer.chosen_answer_id &&
-        this.props.correctAnswers[i] &&
-        this.props.correctAnswers[i].value &&
-        currChosenAnswer.chosen_answer_id === this.props.correctAnswers[i].value) {
+      if (this.isDropdownAnswerCorrect(currChosenAnswer, i)) {
         return sum + 1;
       } else {
         return sum;

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -311,12 +311,23 @@ export default class UniversalInput extends React.Component{
     }, 0);
   }
 
+  determineMultiAnswerIncorrectCount(item) {
+    return item.answers.reduce((sum, answer) => {
+      if (!this.showAsCorrect(answer.id) && this.wasChosen(answer.id)) {
+        return sum + 1;
+      } else {
+        return sum;
+      }
+    }, 0);
+  }
+
   renderReviewPromptForMultipleAnswersQuestion(item) {
     const totalToCheck = this.determineMultiAnswerTotals(item);
     const correctCount = this.determineMultiAnswerCorrectCount(item);
+    const incorrectCount = this.determineMultiAnswerIncorrectCount(item);
     if (correctCount === 0 ) {
       return this.renderIncorrectResponsePrompt();
-    } else if (correctCount < totalToCheck) {
+    } else if (correctCount < totalToCheck || incorrectCount > 0) {
       return this.renderPartiallyCorrectResponsePrompt();
     } else {
       return this.renderCorrectResponsePrompt();

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -90,7 +90,7 @@ export default class UniversalInput extends React.Component{
     let item = this.props.item;
     let messages = "";
     let solution = "";
-    let visuallyHiddenReviewPrompt = "";
+    let visuallyHiddenReviewPrompt = null;
     let items = "";
 
     if(item.messages){
@@ -134,6 +134,7 @@ export default class UniversalInput extends React.Component{
       case "multiple_choice_question":
       case "true_false_question":
         items = this.renderMultipleChoiceQuestion(item, styles);
+        visuallyHiddenReviewPrompt = this.renderReviewPromptForMultipleChoiceQuestion(item);
         break;
       case "matching_question":
         items = <Matching assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult}  item={item} name="answer-option"/>;
@@ -157,9 +158,6 @@ export default class UniversalInput extends React.Component{
         <div className="panel-heading text-center" style={styles.panelHeading}>
           { messages }
         </div>
-        <div aria-live="polite">
-          { visuallyHiddenReviewPrompt }
-        </div>
         <div
           className={item.question_type === "multiple_dropdowns_question" ? "" : "panel-body"}
           style={styles.panelBody}
@@ -168,6 +166,9 @@ export default class UniversalInput extends React.Component{
         </div>
         <div>
           { solution }
+        </div>
+        <div aria-live="polite" style={styles.visuallyHidden}>
+          { visuallyHiddenReviewPrompt }
         </div>
       </div>
     );
@@ -198,6 +199,29 @@ export default class UniversalInput extends React.Component{
         { answers }
       </fieldset>
     );
+  }
+
+  renderReviewPromptForMultipleChoiceQuestion(item) {
+    if (this.props.isResult) {
+      const chosenAnswers = item.answers.filter((answer) => {
+        return this.wasChosen(answer.id);
+      });
+      if (chosenAnswers.length > 0) {
+        const chosenAnswer = chosenAnswers[0];
+        const isCorrectMessage = (this.showAsCorrect(chosenAnswer.id))
+          ? "Your choice is correct."
+          : "Your choice is incorrect.";
+        return (<div>
+          { isCorrectMessage }
+          <div dangerouslySetInnerHTML={ { __html: this.answerFeedback(chosenAnswer.id) } }/>
+        </div>);
+        return null;
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
   }
 
   renderMultipleAnswersQuestion(item, styles) {

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -19,10 +19,12 @@ export default class UniversalInput extends React.Component{
   componentDidMount(){
     CommunicationHandler.sendSizeThrottled();
     CommunicationHandler.hideLMSNavigation();
+    console.log("universal_input component did mount, state = ", this.state, " activeElement = ", document.activeElement);
   }
 
   componentDidUpdate(){
     CommunicationHandler.sendSizeThrottled();
+    console.log("universal_input component did update, state = ", this.state, " activeElement = ", document.activeElement);
   }
 
   getStyles(props, theme){

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -148,7 +148,7 @@ export default class UniversalInput extends React.Component{
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
         break;
       case 'multiple_dropdowns_question':
-        items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} />;
+        items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} visuallyHiddenStyle={styles.visuallyHidden} />;
       break;
     }
 
@@ -174,7 +174,7 @@ export default class UniversalInput extends React.Component{
   }
 
   renderMultipleChoiceQuestion(item, styles) {
-    let answers = item.answers.map((answer) => {
+    let answers = item.answers.map((answer, index) => {
       return (
         <RadioButton
           assessmentKind={this.props.assessmentKind}
@@ -186,6 +186,8 @@ export default class UniversalInput extends React.Component{
           checked={this.wasChosen(answer.id)}
           showAsCorrect={this.showAsCorrect(answer.id)}
           answerFeedback={this.answerFeedback(answer.id)}
+          index={index}
+          visuallyHiddenStyle={styles.visuallyHidden}
           />
       );
     });
@@ -199,7 +201,7 @@ export default class UniversalInput extends React.Component{
   }
 
   renderMultipleAnswersQuestion(item, styles) {
-    let answers = item.answers.map((answer) => {
+    let answers = item.answers.map((answer, index) => {
       return (
         <CheckBox
           assessmentKind={this.props.assessmentKind}
@@ -210,6 +212,8 @@ export default class UniversalInput extends React.Component{
           checked={this.wasChosen(answer.id)}
           showAsCorrect={this.showAsCorrect(answer.id)}
           answerFeedback={this.answerFeedback(answer.id)}
+          index={index}
+          visuallyHiddenStyle={styles.visuallyHidden}
           />
       );
     });

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -196,7 +196,7 @@ export default class UniversalInput extends React.Component{
   renderMultipleChoiceQuestion(item, styles) {
     let refAdded = false;
     let answers = item.answers.map((answer, index) => {
-      const showsFeedback = (!refAdded && this.props.isResult && (this.wasChosen(answer.id) || this.answerFeedback(answer.id)));
+      const showsFeedback = !refAdded && this.doesCheckboxHaveFeedback(answer.id);
       if (showsFeedback) {
         refAdded = true;
       }

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -125,9 +125,7 @@ export default class UniversalInput extends React.Component{
     switch(item.question_type){
       case "multiple_choice_question":
       case "true_false_question":
-        items = item.answers.map((answer) => {
-          return <RadioButton assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-radio" checked={this.wasChosen(answer.id)}  showAsCorrect={this.showAsCorrect(answer.id)} answerFeedback={this.answerFeedback(answer.id)} />;
-        });
+        items = this.renderMultipleChoiceQuestion(item, styles);
         break;
       case "matching_question":
         items = <Matching assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult}  item={item} name="answer-option"/>;
@@ -159,6 +157,30 @@ export default class UniversalInput extends React.Component{
         </div>
         { solution }
       </div>
+    );
+  }
+
+  renderMultipleChoiceQuestion(item, styles) {
+    let answers = item.answers.map((answer) => {
+      return (
+        <RadioButton
+          assessmentKind={this.props.assessmentKind}
+          isDisabled={this.props.isResult}
+          key={item.id + "_" + answer.id}
+          item={answer}
+          name="answer-radio"
+          checked={this.wasChosen(answer.id)}
+          showAsCorrect={this.showAsCorrect(answer.id)}
+          answerFeedback={this.answerFeedback(answer.id)}
+          />
+      );
+    });
+
+    return (
+      <fieldset tabIndex={-1}>
+        <legend style={styles.legend} tabIndex={-1}>Multiple Choice Question</legend>
+        { answers }
+      </fieldset>
     );
   }
 

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -50,6 +50,14 @@ export default class UniversalInput extends React.Component{
       panelBody: {
         padding: theme.panelBodyPadding,
         marginTop: "-20px",
+      },
+      legend: {
+        position: "absolute",
+        left: "-10000px",
+        top: "auto",
+        width: "1px",
+        height: "1px",
+        overflow: "hidden"
       }
     }
   }
@@ -78,13 +86,12 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  render(){
-    var styles = this.getStyles(this.props, this.context.theme)
-    var item = this.props.item;
-    var assessmentResult = AssessmentStore.assessmentResult();
-    var messages = '';
-    var solution = '';
-    var items = '';
+  render() {
+    let styles = this.getStyles(this.props, this.context.theme);
+    let item = this.props.item;
+    let messages = "";
+    let solution = "";
+    let items = "";
 
     if(item.messages){
       var renderedMessages = item.messages.map(function(message){
@@ -132,9 +139,7 @@ export default class UniversalInput extends React.Component{
         items = <TextArea assessmentKind={this.props.assessmentKind} completed={this.props.completed} isDisabled={this.props.isResult} key="textarea_essay_input" item={item} initialText={this.props.chosen} />;
         break;
       case "multiple_answers_question":
-        items = item.answers.map((answer) => {
-          return <CheckBox assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult} key={item.id + "_" + answer.id} item={answer} name="answer-check" checked={this.wasChosen(answer.id)} showAsCorrect={this.showAsCorrect(answer.id)} answerFeedback={this.answerFeedback(answer.id)} />;
-        });
+        items = this.renderMultipleAnswersQuestion(item, styles);
         break;
       case "mom_embed":
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
@@ -144,23 +149,46 @@ export default class UniversalInput extends React.Component{
       break;
     }
 
+    return (
+      <div className="panel-messages-container panel panel-default" style={styles.panel}>
+        <div className="panel-heading text-center" style={styles.panelHeading}>
+          { messages }
+        </div>
+        <div
+          className={item.question_type === "multiple_dropdowns_question" ? "" : "panel-body"}
+          style={styles.panelBody}
+          >
+          { items }
+        </div>
+        { solution }
+      </div>
+    );
+  }
 
-    return (<div className="panel-messages-container panel panel-default" style={styles.panel}>
-              <div className="panel-heading text-center" style={styles.panelHeading}>
-                {/*{item.title}*/}
-                {messages}
-              </div>
-              <div className={item.question_type === 'multiple_dropdowns_question' ? "" : "panel-body"}
-                   style={styles.panelBody}
-              >
-                {items}
-              </div>
-              {solution}
-            </div>
+  renderMultipleAnswersQuestion(item, styles) {
+    let answers = item.answers.map((answer) => {
+      return (
+        <CheckBox
+          assessmentKind={this.props.assessmentKind}
+          isDisabled={this.props.isResult}
+          key={item.id + "_" + answer.id}
+          item={answer} name="answer-check"
+          checked={this.wasChosen(answer.id)}
+          showAsCorrect={this.showAsCorrect(answer.id)}
+          answerFeedback={this.answerFeedback(answer.id)}
+          />
+      );
+    });
 
-           );
+    return (
+      <fieldset>
+        <legend style={styles.legend}>Select all correct answers</legend>
+        { answers }
+      </fieldset>
+    );
   }
 }
+
 UniversalInput.propTypes = {
   item: React.PropTypes.object.isRequired,
   isResult: React.PropTypes.bool,

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -126,7 +126,7 @@ export default class UniversalInput extends React.Component{
     }
     if (this.props.isResult) {
       visuallyHiddenReviewPrompt = (<div style={styles.visuallyHidden}>
-        Your selection has been graded.  Please navigate forward to review your answers and receive feedback.
+        Your selection has been evaluated.  Please navigate forward to receive feedback.
       </div>);
     }
 

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -19,12 +19,10 @@ export default class UniversalInput extends React.Component{
   componentDidMount(){
     CommunicationHandler.sendSizeThrottled();
     CommunicationHandler.hideLMSNavigation();
-    console.log("universal_input component did mount, state = ", this.state, " activeElement = ", document.activeElement);
   }
 
   componentDidUpdate(){
     CommunicationHandler.sendSizeThrottled();
-    console.log("universal_input component did update, state = ", this.state, " activeElement = ", document.activeElement);
   }
 
   getStyles(props, theme){

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -49,14 +49,14 @@ export default class UniversalInput extends React.Component{
         marginTop: "-20px",
       },
       visuallyHidden: {
-        //position: "absolute !important",
-        //left: "-10000px",
-        //top: "auto",
-        //width: "1px",
-        //height: "1px",
-        //overflow: "hidden",
-        //clip: "rect(1px, 1px, 1px, 1px)",
-        //whiteSpace: "nowrap"
+        position: "absolute !important",
+        left: "-10000px",
+        top: "auto",
+        width: "1px",
+        height: "1px",
+        overflow: "hidden",
+        clip: "rect(1px, 1px, 1px, 1px)",
+        whiteSpace: "nowrap"
       }
     }
   }
@@ -157,7 +157,7 @@ export default class UniversalInput extends React.Component{
         <div className="panel-heading text-center" style={styles.panelHeading}>
           { messages }
         </div>
-        <div aria-live="polite">
+        <div>
           { visuallyHiddenReviewPrompt }
         </div>
         <div

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -157,7 +157,7 @@ export default class UniversalInput extends React.Component{
         <div className="panel-heading text-center" style={styles.panelHeading}>
           { messages }
         </div>
-        <div>
+        <div aria-live="polite">
           { visuallyHiddenReviewPrompt }
         </div>
         <div

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -90,7 +90,7 @@ export default class UniversalInput extends React.Component{
       var renderedMessages = item.messages.map(function(message){
         return (<li>{message}</li>);
       });
-      render (<div className="panel-messages alert alert-danger" role="alert">
+      return (<div className="panel-messages alert alert-danger" role="alert">
         <ul>
           {renderedMessages}
         </ul>
@@ -113,7 +113,7 @@ export default class UniversalInput extends React.Component{
     * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
     */
     if (item.isGraded && item.solution) {
-      render (<div className="panel-footer text-center">
+      return (<div className="panel-footer text-center">
         <div
                 dangerouslySetInnerHTML={{
                 __html: item.solution
@@ -125,7 +125,7 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  renderDefaultReviewPrompt() {
+  renderDefaultReviewPrompt(styles) {
     if (this.props.isResult) {
       return (<div style={styles.visuallyHidden}>
         Your selection has been evaluated.  Please navigate forward to receive feedback.
@@ -159,19 +159,19 @@ export default class UniversalInput extends React.Component{
         break;
       case "matching_question":
         items = <Matching assessmentKind={this.props.assessmentKind} isDisabled={this.props.isResult}  item={item} name="answer-option"/>;
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
         break;
       case "essay_question":
         items = <TextArea assessmentKind={this.props.assessmentKind} completed={this.props.completed} isDisabled={this.props.isResult} key="textarea_essay_input" item={item} initialText={this.props.chosen} />;
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
         break;
       case "multiple_answers_question":
         items = this.renderMultipleAnswersQuestion(item, styles);
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
         break;
       case "mom_embed":
         items = <MomEmbed assessmentKind={this.props.assessmentKind} key={item.id} item={item} redisplayJWT={this.props.chosen ? this.props.chosen : null} registerGradingCallback={this.props.registerGradingCallback} />;
-        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt();
+        visuallyHiddenReviewPrompt = this.renderDefaultReviewPrompt(styles);
         break;
       case 'multiple_dropdowns_question':
         items = <MultiDropDown assessmentKind={this.props.assessmentKind} isResult={this.props.isResult} key={item.id} item={item} selectedAnswers={this.props.chosen} selectCorrectAnswer={this.props.correctAnswers && this.props.correctAnswers.length > 0} />;

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -79,6 +79,7 @@ export default class CheckBox extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer that was chosen"
           alt="Icon indicating that a correct answer was chosen"
+          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -89,6 +90,7 @@ export default class CheckBox extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer that was not chosen"
           alt="Icon indicating that a correct answer was not chosen"
+          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -99,6 +101,7 @@ export default class CheckBox extends React.Component {
           className="wrongIndicator"
           aria-label="Wrong answer that was chosen"
           alt="Icon indicating that a wrong answer was chosen"
+          tabIndex="0"
           style={styles.checkStyleWrong}
           />
       );

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -23,10 +23,10 @@ export default class CheckBox extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div>
+      <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
-          <label style={btnLabelStyles}>
+          <label style={btnLabelStyles} htmlFor={this.props.name}>
             <span style={{display: "table-cell"}}>
               <input
                 style={{margin: 0}}
@@ -34,6 +34,7 @@ export default class CheckBox extends React.Component {
                 defaultChecked={this.props.checked}
                 disabled={this.props.isDisabled}
                 name={this.props.name}
+                id={this.props.name}
                 onClick={() => { this.answerSelected(); }} />
             </span>
             <span style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}} dangerouslySetInnerHTML={{__html: this.props.item.material}}/>

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -26,7 +26,7 @@ export default class CheckBox extends React.Component {
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
-          <label style={btnLabelStyles} htmlFor={this.props.name}>
+          <label style={btnLabelStyles}>
             <span style={{display: "table-cell"}}>
               <input
                 style={{margin: 0}}

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -130,7 +130,7 @@ export default class CheckBox extends React.Component {
       let feedback = this.getFeedback();
 
       return (
-        <div className="check_answer_result" style={feedback.styles} tabIndex={this.getTabIndex()}>{feedback.text}</div>
+        <div className="check_answer_result" style={feedback.styles}>{feedback.text}</div>
       );
     }
   }

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -23,11 +23,11 @@ export default class CheckBox extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div className="checkbox-wrapper">
+      <div className="checkbox-wrapper" tabIndex={-1}>
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
-          <label style={btnLabelStyles}>
-            <span style={{display: "table-cell"}}>
+        <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()} tabIndex={-1}>
+          <label style={btnLabelStyles} tabIndex={-1}>
+            <span style={{display: "table-cell"}} tabIndex={-1}>
               <input
                 style={{margin: 0}}
                 type="checkbox"
@@ -35,9 +35,15 @@ export default class CheckBox extends React.Component {
                 disabled={this.props.isDisabled}
                 name={this.props.name}
                 id={this.props.name}
-                onClick={() => { this.answerSelected(); }} />
+                onClick={() => { this.answerSelected(); }}
+                tabIndex="0"
+                />
             </span>
-            <span style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}} dangerouslySetInnerHTML={{__html: this.props.item.material}}/>
+            <span
+              style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
+              dangerouslySetInnerHTML={{__html: this.props.item.material}}
+              tabIndex={this.getTabIndex()}
+              />
           </label>
           {this.answerFeedback()}
         </div>
@@ -124,8 +130,18 @@ export default class CheckBox extends React.Component {
       let feedback = this.getFeedback();
 
       return (
-        <div className="check_answer_result" style={feedback.styles} tabIndex="0">{feedback.text}</div>
+        <div className="check_answer_result" style={feedback.styles} tabIndex={this.getTabIndex()}>{feedback.text}</div>
       );
+    }
+  }
+
+  getTabIndex() {
+    // if question has been answered and this answer has not been interacted with and it's incorrect, add to tab order,
+    // otherwise ignore it.
+    if (this.props.showAsCorrect !== null && !this.unselectedIncorrectAnswer()) {
+      return "0";
+    } else {
+      return -1;
     }
   }
 
@@ -162,7 +178,6 @@ export default class CheckBox extends React.Component {
     return this.props.showAsCorrect === false && this.props.checked === true;
   }
 
-  // unused, but here for completeness
   unselectedIncorrectAnswer() {
     return this.props.showAsCorrect === false && this.props.checked === false;
   }

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -23,7 +23,7 @@ export default class CheckBox extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     const inputProps = {
-      style: { margin: 0 },
+      style: { margin: 0, float: "left", position: "absolute" },
       type: "checkbox",
       defaultChecked: this.props.checked,
       name: this.props.name,
@@ -47,11 +47,9 @@ export default class CheckBox extends React.Component {
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
           <label style={btnLabelStyles}>
-            <span style={{display: "table-cell"}}>
-              <input { ...inputProps }/>
-            </span>
+            <input { ...inputProps }/>
             <span
-              style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
+              style={{display: "inline-block", paddingLeft: "25px", fontWeight: "normal"}}
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -124,7 +124,7 @@ export default class CheckBox extends React.Component {
       let feedback = this.getFeedback();
 
       return (
-        <div className="check_answer_result" style={feedback.styles}>{feedback.text}</div>
+        <div className="check_answer_result" style={feedback.styles} tabIndex="0">{feedback.text}</div>
       );
     }
   }

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -50,8 +50,7 @@ export default class CheckBox extends React.Component {
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>
-          <div aria-live="polite" role="region" aria-labelledby={"feedback"+this.props.index}>
-            <div style={this.props.visuallyHiddenStyle} id={"feedback"+this.props.index}>Feedback Region {this.props.index}</div>
+          <div>
             {this.answerFeedback()}
           </div>
         </div>

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -22,21 +22,28 @@ export default class CheckBox extends React.Component {
      *
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
+    const inputProps = {
+      style: { margin: 0 },
+      type: "checkbox",
+      defaultChecked: this.props.checked,
+      name: this.props.name,
+      id: this.props.name,
+      onClick: () => { this.answerSelected(); }
+    };
+    if (this.selectedCorrectAnswer()) {
+      inputProps["aria-invalid"] = false;
+      inputProps["aria-describedby"] = this.feedbackId();
+    } else if (this.unselectedCorrectAnswer() || this.selectedIncorrectAnswer()) {
+      inputProps["aria-invalid"] = true;
+      inputProps["aria-describedby"] = this.feedbackId();
+    }
     return (
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
           <label style={btnLabelStyles}>
             <span style={{display: "table-cell"}}>
-              <input
-                style={{margin: 0}}
-                type="checkbox"
-                defaultChecked={this.props.checked}
-                disabled={this.props.isDisabled}
-                name={this.props.name}
-                id={this.props.name}
-                onClick={() => { this.answerSelected(); }}
-              />
+              <input { ...inputProps }/>
             </span>
             <span
               style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
@@ -47,6 +54,10 @@ export default class CheckBox extends React.Component {
         </div>
       </div>
     );
+  }
+
+  feedbackId() {
+    return this.props.id + "Hint";
   }
 
   renderAnswerIndicator() {
@@ -128,7 +139,7 @@ export default class CheckBox extends React.Component {
       let feedback = this.getFeedback();
 
       return (
-        <div className="check_answer_result" style={feedback.styles}>{feedback.text}</div>
+        <div id={this.feedbackId()} className="check_answer_result" style={feedback.styles}>{feedback.text}</div>
       );
     }
   }

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -37,6 +37,11 @@ export default class CheckBox extends React.Component {
       inputProps["aria-invalid"] = true;
       inputProps["aria-describedby"] = this.feedbackId();
     }
+    if (this.props.addRef) {
+      inputProps["ref"] = (node) => {
+        this.props.setRef(node);
+      };
+    }
     return (
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -23,11 +23,11 @@ export default class CheckBox extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div className="checkbox-wrapper" tabIndex={-1}>
+      <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()} tabIndex={-1}>
-          <label style={btnLabelStyles} tabIndex={-1}>
-            <span style={{display: "table-cell"}} tabIndex={-1}>
+        <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
+          <label style={btnLabelStyles}>
+            <span style={{display: "table-cell"}}>
               <input
                 style={{margin: 0}}
                 type="checkbox"
@@ -36,13 +36,11 @@ export default class CheckBox extends React.Component {
                 name={this.props.name}
                 id={this.props.name}
                 onClick={() => { this.answerSelected(); }}
-                tabIndex="0"
-                />
+              />
             </span>
             <span
               style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
-              tabIndex={this.getTabIndex()}
               />
           </label>
           {this.answerFeedback()}
@@ -79,7 +77,6 @@ export default class CheckBox extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer that was chosen"
           alt="Icon indicating that a correct answer was chosen"
-          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -90,7 +87,6 @@ export default class CheckBox extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer that was not chosen"
           alt="Icon indicating that a correct answer was not chosen"
-          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -101,7 +97,6 @@ export default class CheckBox extends React.Component {
           className="wrongIndicator"
           aria-label="Wrong answer that was chosen"
           alt="Icon indicating that a wrong answer was chosen"
-          tabIndex="0"
           style={styles.checkStyleWrong}
           />
       );
@@ -135,16 +130,6 @@ export default class CheckBox extends React.Component {
       return (
         <div className="check_answer_result" style={feedback.styles}>{feedback.text}</div>
       );
-    }
-  }
-
-  getTabIndex() {
-    // if question has been answered and this answer has not been interacted with and it's incorrect, add to tab order,
-    // otherwise ignore it.
-    if (this.props.showAsCorrect !== null && !this.unselectedIncorrectAnswer()) {
-      return "0";
-    } else {
-      return -1;
     }
   }
 

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -50,7 +50,10 @@ export default class CheckBox extends React.Component {
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>
-          {this.answerFeedback()}
+          <div aria-live="polite" role="region" aria-labelledby={"feedback"+this.props.index}>
+            <div style={this.props.visuallyHiddenStyle} id={"feedback"+this.props.index}>Feedback Region {this.props.index}</div>
+            {this.answerFeedback()}
+          </div>
         </div>
       </div>
     );
@@ -86,8 +89,7 @@ export default class CheckBox extends React.Component {
         <img
           src="/assets/correct.png"
           className="correctIndicator"
-          aria-label="Correct Answer that was chosen"
-          alt="Icon indicating that a correct answer was chosen"
+          alt="Correct"
           style={styles.checkStyleCorrect}
           />
       );
@@ -96,8 +98,7 @@ export default class CheckBox extends React.Component {
         <img
           src="/assets/correct.png"
           className="correctIndicator"
-          aria-label="Correct Answer that was not chosen"
-          alt="Icon indicating that a correct answer was not chosen"
+          alt="Correct but not Selected"
           style={styles.checkStyleCorrect}
           />
       );
@@ -106,8 +107,7 @@ export default class CheckBox extends React.Component {
         <img
           src="/assets/incorrect.png"
           className="wrongIndicator"
-          aria-label="Wrong answer that was chosen"
-          alt="Icon indicating that a wrong answer was chosen"
+          alt="Incorrect"
           style={styles.checkStyleWrong}
           />
       );

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -27,7 +27,7 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   render() {
-    const ariaLabelSelects = this.findAndReplace(true);
+    const ariaLabelSelects = "Review of the question and the selected answers: " + this.findAndReplace(true);
     /**
      * Note on dangerouslySetInnerHTML Usage
      *
@@ -42,7 +42,6 @@ export default class MultiDropDown extends BaseComponent {
     return (
       <div>
         <div
-          tabIndex="0"
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
         <div style={{position:"absolute",left:"-10000px",top:"auto",height:"1px",width:"1px",overflow:"hidden"}} tabIndex="0" role="group" aria-label="Review your answer" >
@@ -154,7 +153,7 @@ export default class MultiDropDown extends BaseComponent {
         `<span style="display:inline-block">
           <span style="display:flex">
             <select ${selectPropsStr}>
-              <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select ${nMatch} choice" value="null">[Select]</option>
+              <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select an answer for ${nMatch}" value="null">[Select]</option>
               ${this.answerOptions(correctAnswer, nMatch)}
             </select>
             ${this.answerCheckMarks(correctAnswer, nMatch, i)}

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -38,21 +38,17 @@ export default class MultiDropDown extends BaseComponent {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div>
+      <div tabIndex={-1}>
         <div
-          tabIndex="0"
+          tabIndex={-1}
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
         <div
           style={this.getReviewAnswerStyle()}
-          tabIndex="0"
+          tabIndex={-1}
           role="group"
           aria-label="Review your answer"
           >
-            <div
-              id="question_result_container"
-              dangerouslySetInnerHTML={{__html: this.findAndReplace(true)}}
-              />
         </div>
         {this.props.isResult ? this.answerFeedback() : ""}
       </div>
@@ -95,7 +91,7 @@ export default class MultiDropDown extends BaseComponent {
       }
 
       return (
-        `<span style="display:inline-block" >
+        `<span style="display:inline-block">
           <span style="display:flex">
             <select
               name="${nMatch}"
@@ -103,6 +99,7 @@ export default class MultiDropDown extends BaseComponent {
               aria-label=${this.getAriaAnswerLabel(nMatch, str)}
               ${disabled}
               style="${cursorNotAllowed}"
+              tabIndex="0"
             >
               <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select ${nMatch} choice" value="null">[Select]</option>
               ${this.answerOptions(correctAnswer, nMatch)}

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -40,10 +40,12 @@ export default class MultiDropDown extends BaseComponent {
     return (
       <div>
         <div
-          aria-live="polite"
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
-        {this.props.isResult ? this.answerFeedback() : ""}
+        <div aria-live="polite" role="region" aria-labelledby="">
+          <div style={this.props.visuallyHiddenStyle} id="select_feedback">Feedback</div>
+          {this.props.isResult ? this.answerFeedback() : ""}
+        </div>
       </div>
     );
   }
@@ -178,7 +180,6 @@ export default class MultiDropDown extends BaseComponent {
 
 
       if(!!selAnswer && (!!correctAnswer && selAnswer.chosen_answer_id === correctAnswer.value)){
-        const altText = `Correct selection.  Feedback is listed under (${i}).`;
         answerCheck = (
           `<span
                 style="display:inline-block;"
@@ -190,14 +191,13 @@ export default class MultiDropDown extends BaseComponent {
                   height="20px"
                   src="/assets/correct.png"
                   style="${correctStyle}"
-                  alt=${altText}
+                  alt="Correct"
                   /> (${i})
               </span>
             </span>`
         );
       }
       else{
-        const altText = `Incorrect selection. Feeback is listed under (${i}).`
         answerCheck = (
           `<span
                 style="display:inline-block;"
@@ -209,7 +209,7 @@ export default class MultiDropDown extends BaseComponent {
                   height="20px"
                   src="/assets/incorrect.png"
                   style="${incorrectStyle}"
-                  alt=${altText}
+                  alt="Incorrect"
                 /> (${i})
               </span>
             </span>`

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -40,6 +40,7 @@ export default class MultiDropDown extends BaseComponent {
     return (
       <div>
         <div
+          aria-live="polite"
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
         {this.props.isResult ? this.answerFeedback() : ""}

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -40,7 +40,7 @@ export default class MultiDropDown extends BaseComponent {
     return (
       <div tabIndex={-1}>
         <div
-          tabIndex={-1}
+          tabIndex="0"
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
         <div

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -281,6 +281,7 @@ export default class MultiDropDown extends BaseComponent {
             className="check_answer_result"
             style={feedbackStyles}
             dangerouslySetInnerHTML={this.answerFeedbackMarkup(i, feedback[answerId], correctResponse)}
+            tabIndex="0"
             />
         );
       }

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -62,7 +62,7 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   quoteObjectAsCss(v) {
-    const asCss = Object.keys(v).map((k) => `${k}: ${v[k]}`).join("; ");
+    const asCss = Object.entries(v).map((entry) => `${entry[0]}: ${entry[1]}`).join("; ");
     return `"${asCss}"`;
   }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -92,7 +92,7 @@ export default class MultiDropDown extends BaseComponent {
               ${disabled}
               style="${cursorNotAllowed}"
             >
-              <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select ${nMatch} choice" value="null">[Select]</option>
+              <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select the choice which best fits the sentence" value="null">[Select]</option>
               ${this.answerOptions(correctAnswer, nMatch)}
             </select>
             ${this.answerCheckMarks(correctAnswer, nMatch, i)}
@@ -107,7 +107,8 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   getAnswerFeedbackDivId(answer) {
-    return answer.dropdown_id + "_" + answer.chosen_answer_id + "Hint";
+    const dropDownId = answer.value || answer.chosen_answer_id;
+    return dropDownId + "Hint";
   }
 
   answerOptions(correctAnswer, nMatch) {

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -92,7 +92,7 @@ export default class MultiDropDown extends BaseComponent {
     const that = this;
 
     return this.props.item.material.replace(re, (match) => {
-      let str = `"Multiple dropdowns, read surrounding text"`;
+      let str = "\"Multiple dropdowns, read surrounding text\"";
       let nMatch = match.replace(new RegExp("\\[|\\]", "g"), ""); //from '[shortcode]' to 'shortcode'
       let correctAnswer = this.props.item.correct.find((correctAns) => {
         return correctAns.name === nMatch;

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -124,7 +124,6 @@ export default class MultiDropDown extends BaseComponent {
         id: dropdownId
       };
       selectProps["aria-label"] = ariaLabel;
-      selectProps["tabindex"] = "0";
 
       // Disable dropdowns if this is the results page or if confidence levels have been selected
       if (isResult || typeof item.confidenceLevel !== "undefined") {

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -106,8 +106,14 @@ export default class MultiDropDown extends BaseComponent {
     return this.state.ariaAnswersLabels[nMatch] ? this.state.ariaAnswersLabels[nMatch] : str;
   }
 
+  getAnswerFeedbackDivId(answer) {
+    return answer.dropdown_id + "_" + answer.chosen_answer_id + "Hint";
+  }
+
   answerOptions(correctAnswer, nMatch) {
     return this.props.item.dropdowns[nMatch].map((answer) => {
+      const answerDivId = this.getAnswerFeedbackDivId(answer);
+
       let selected = "";
       let disabled = "";
 
@@ -133,8 +139,9 @@ export default class MultiDropDown extends BaseComponent {
       }
 
       if ((this.props.isResult && !!correctAnswer) && correctAnswer.value !== answer.value) disabled = "disabled";
+      const describedby = (this.props.isResult) ? `aria-describedby=${answerDivId}` : ""
 
-      return `<option ${selected} ${disabled} value=${answer.value}>${answer.name}</option>`;
+      return `<option ${selected} ${disabled} ${describedby} value=${answer.value}>${answer.name}</option>`;
     });
   }
 
@@ -227,7 +234,8 @@ export default class MultiDropDown extends BaseComponent {
     let correctResponse;
 
     return selectedAnswers.map((answer, i) => {
-      let answerId = answer.dropdown_id + answer.chosen_answer_id;
+      const answerId = answer.dropdown_id + answer.chosen_answer_id;
+      const answerDivId = this.getAnswerFeedbackDivId(answer);
 
       if (answerId.indexOf(feedback)) {
         let feedbackStyles = {};
@@ -253,6 +261,7 @@ export default class MultiDropDown extends BaseComponent {
          */
         return (
           <div
+            id={answerDivId}
             className="check_answer_result"
             style={feedbackStyles}
             dangerouslySetInnerHTML={this.answerFeedbackMarkup(i, feedback[answerId], correctResponse)}

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -61,12 +61,20 @@ export default class MultiDropDown extends BaseComponent {
     this.removeListeners();
   }
 
+  quoteObjectAsCss(v) {
+    const asCss = Object.keys(v).map((k) => `${k}: ${v[k]}`).join("; ");
+    return `"${asCss}"`;
+  }
+
+  isAlreadyQuoted(v) {
+    return (v && v.match && v.match(/^\".+\"$/));
+  }
+
   quoteAttributes(v) {
     if (typeof(v) === "object") {
-      const asCss = Object.keys(v).map((k) => `${k}: ${v[k]}`).join("; ");
-      return `"${asCss}"`;
+      return this.quoteObjectAsCss(v);
     } else {
-      return (v && v.match && v.match(/^\".+\"$/)) ? v : `"${v}"`;
+      return (this.isAlreadyQuoted(v)) ? v : `"${v}"`;
     }
   }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -350,7 +350,7 @@ export default class MultiDropDown extends BaseComponent {
     shortcodes.forEach((shortcode, i) => {
       document.getElementById(`dropdown_${shortcode}`).addEventListener("change", this.handleShortcodeChange);
       document.getElementById(`dropdown_${shortcode}`).addEventListener("focus", this.keepFocus.bind(this, `dropdown_${shortcode}`));
-      document.getElementById(`dropdown_${shortcode}`).addEventListener("focus", this.loseFocus);
+      document.getElementById(`dropdown_${shortcode}`).addEventListener("blur", this.loseFocus.bind(this));
     });
   }
 
@@ -360,7 +360,7 @@ export default class MultiDropDown extends BaseComponent {
     shortcodes.forEach((shortcode, i) => {
       document.getElementById(`dropdown_${shortcode}`).removeEventListener("change", this.handleShortcodeChange);
       document.getElementById(`dropdown_${shortcode}`).removeEventListener("focus", this.keepFocus.bind(this, `dropdown_${shortcode}`));
-      document.getElementById(`dropdown_${shortcode}`).removeEventListener("focus", this.loseFocus);
+      document.getElementById(`dropdown_${shortcode}`).removeEventListener("blur", this.loseFocus.bind(this));
     });
   }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -22,6 +22,7 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   componentWillUpdate() {
+    console.log("component will update, state = ", this.state, " activeElement = ", document.activeElement);
     this.removeListeners();
   }
 
@@ -55,6 +56,7 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   componentDidUpdate() {
+    console.log("component did update, state = ", this.state, " activeElement = ", document.activeElement);
     this.addListeners();
     if (this.props.isResult && this.props.shouldFocusForFeedback && this.focusDropdown) {
       const focusDropdownEle = document.getElementById(this.focusDropdown);
@@ -66,10 +68,12 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   componentDidMount() {
+  console.log("component did mount, state = ", this.state, " activeElement = ", document.activeElement);
     this.addListeners();
   }
 
   componentWillUnmount() {
+    console.log("component will unmount, state = ", this.state, " activeElement = ", document.activeElement);
     this.removeListeners();
   }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -92,7 +92,7 @@ export default class MultiDropDown extends BaseComponent {
     const that = this;
 
     return this.props.item.material.replace(re, (match) => {
-      let str = `"blank ${i}"`;
+      let str = `"Multiple dropdowns, read surrounding text"`;
       let nMatch = match.replace(new RegExp("\\[|\\]", "g"), ""); //from '[shortcode]' to 'shortcode'
       let correctAnswer = this.props.item.correct.find((correctAns) => {
         return correctAns.name === nMatch;
@@ -135,7 +135,7 @@ export default class MultiDropDown extends BaseComponent {
         `<span style="display:inline-block">
           <span style="display:flex">
             <select ${selectPropsStr}>
-              <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select the choice which best fits the sentence" value="null">[Select]</option>
+              <option ${!this.state[nMatch] ? "selected" : ""} disabled value="null">[Select]</option>
               ${this.answerOptions(correctAnswer, nMatch)}
             </select>
             ${this.answerCheckMarks(correctAnswer, nMatch, i)}

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -38,18 +38,10 @@ export default class MultiDropDown extends BaseComponent {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     return (
-      <div tabIndex={-1}>
+      <div>
         <div
-          tabIndex="0"
           dangerouslySetInnerHTML={{__html: this.findAndReplace()}}
           />
-        <div
-          style={this.getReviewAnswerStyle()}
-          tabIndex={-1}
-          role="group"
-          aria-label="Review your answer"
-          >
-        </div>
         {this.props.isResult ? this.answerFeedback() : ""}
       </div>
     );
@@ -99,7 +91,6 @@ export default class MultiDropDown extends BaseComponent {
               aria-label=${this.getAriaAnswerLabel(nMatch, str)}
               ${disabled}
               style="${cursorNotAllowed}"
-              tabIndex="0"
             >
               <option ${!this.state[nMatch] ? "selected" : ""} disabled aria-label="select ${nMatch} choice" value="null">[Select]</option>
               ${this.answerOptions(correctAnswer, nMatch)}
@@ -113,17 +104,6 @@ export default class MultiDropDown extends BaseComponent {
 
   getAriaAnswerLabel(nMatch, str) {
     return this.state.ariaAnswersLabels[nMatch] ? this.state.ariaAnswersLabels[nMatch] : str;
-  }
-
-  getReviewAnswerStyle() {
-    return {
-      position: "absolute",
-      left: "-10000px",
-      top: "auto",
-      height: "1px",
-      width: "1px",
-      overflow: "hidden"
-    }
   }
 
   answerOptions(correctAnswer, nMatch) {
@@ -192,7 +172,6 @@ export default class MultiDropDown extends BaseComponent {
         answerCheck = (
           `<span
                 style="display:inline-block;"
-                tabindex="0"
                 aria-label="Correct: ${item.feedback[correctAnswer.name+correctAnswer.value]}"
             >
               <span style=${`"${checkboxWrapper}"`} >
@@ -211,7 +190,6 @@ export default class MultiDropDown extends BaseComponent {
         answerCheck = (
           `<span
                 style="display:inline-block;"
-                tabindex="0"
                 aria-label="Wrong: ${item.feedback[correctAnswer.name+correctAnswer.value]}"
             >
               <span style=${`"${checkboxWrapper}"`} >
@@ -278,7 +256,6 @@ export default class MultiDropDown extends BaseComponent {
             className="check_answer_result"
             style={feedbackStyles}
             dangerouslySetInnerHTML={this.answerFeedbackMarkup(i, feedback[answerId], correctResponse)}
-            tabIndex="0"
             />
         );
       }

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -51,6 +51,13 @@ export default class MultiDropDown extends BaseComponent {
 
   componentDidUpdate() {
     this.addListeners();
+    if (this.props.isResult && this.props.shouldFocusForFeedback && this.focusDropdown) {
+      const focusDropdownEle = document.getElementById(this.focusDropdown);
+      if (focusDropdownEle) {
+        focusDropdownEle.focus();
+        this.focusDropdown = null;
+      }
+    }
   }
 
   componentDidMount() {
@@ -82,6 +89,8 @@ export default class MultiDropDown extends BaseComponent {
     let i = 0;
     let re = new RegExp(`\\[${Object.keys(this.props.item.dropdowns).join("\\]|\\[")}\\]`, "gi");
 
+    const that = this;
+
     return this.props.item.material.replace(re, (match) => {
       let str = `"blank ${i}"`;
       let nMatch = match.replace(new RegExp("\\[|\\]", "g"), ""); //from '[shortcode]' to 'shortcode'
@@ -90,11 +99,16 @@ export default class MultiDropDown extends BaseComponent {
       });
       const describedBy = this.getAnswerFeedbackDivId(i);
 
+      const dropdownId = `dropdown_${nMatch}`;
+      if (i === 0 && this.props.isResult) {
+        that.focusDropdown = dropdownId;
+      }
+
       i++;
 
       const selectProps = {
         name: nMatch,
-        id: `dropdown_${nMatch}`
+        id: dropdownId
       };
       selectProps["aria-label"] = this.getAriaAnswerLabel(nMatch, str);
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -10,7 +10,8 @@ export default class MultiDropDown extends BaseComponent {
     super(props, context);
 
     this.state = {
-      ariaAnswersLabels: {}
+      ariaAnswersLabels: {},
+      focusedDropdownId: null
     };
 
     this.findAndReplace = this.findAndReplace.bind(this);
@@ -22,7 +23,6 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   componentWillUpdate() {
-    console.log("component will update, state = ", this.state, " activeElement = ", document.activeElement);
     this.removeListeners();
   }
 
@@ -56,7 +56,6 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   componentDidUpdate() {
-    console.log("component did update, state = ", this.state, " activeElement = ", document.activeElement);
     this.addListeners();
     if (this.props.isResult && this.props.shouldFocusForFeedback && this.focusDropdown) {
       const focusDropdownEle = document.getElementById(this.focusDropdown);
@@ -64,16 +63,19 @@ export default class MultiDropDown extends BaseComponent {
         focusDropdownEle.focus();
         this.focusDropdown = null;
       }
+    } else if (this.state.focusedDropdownId) {
+      const dropdownEle = document.getElementById(this.state.focusedDropdownId);
+      if (dropdownEle) {
+        dropdownEle.focus();
+      }
     }
   }
 
   componentDidMount() {
-  console.log("component did mount, state = ", this.state, " activeElement = ", document.activeElement);
     this.addListeners();
   }
 
   componentWillUnmount() {
-    console.log("component will unmount, state = ", this.state, " activeElement = ", document.activeElement);
     this.removeListeners();
   }
 
@@ -346,8 +348,9 @@ export default class MultiDropDown extends BaseComponent {
     let shortcodes = Object.keys(this.props.item.dropdowns);
 
     shortcodes.forEach((shortcode, i) => {
-      console.log(`generating event listener for dropdown_${shortcode}`);
       document.getElementById(`dropdown_${shortcode}`).addEventListener("change", this.handleShortcodeChange);
+      document.getElementById(`dropdown_${shortcode}`).addEventListener("focus", this.keepFocus.bind(this, `dropdown_${shortcode}`));
+      document.getElementById(`dropdown_${shortcode}`).addEventListener("focus", this.loseFocus);
     });
   }
 
@@ -356,6 +359,8 @@ export default class MultiDropDown extends BaseComponent {
 
     shortcodes.forEach((shortcode, i) => {
       document.getElementById(`dropdown_${shortcode}`).removeEventListener("change", this.handleShortcodeChange);
+      document.getElementById(`dropdown_${shortcode}`).removeEventListener("focus", this.keepFocus.bind(this, `dropdown_${shortcode}`));
+      document.getElementById(`dropdown_${shortcode}`).removeEventListener("focus", this.loseFocus);
     });
   }
 
@@ -371,6 +376,14 @@ export default class MultiDropDown extends BaseComponent {
       "dropdown_id": e.target.name,
       "chosen_answer_id": e.target.value
     });
+  }
+
+  keepFocus(elementId) {
+    this.setState({ focusedDropdownId: elementId });
+  }
+
+  loseFocus() {
+    this.setState({ focusedDropdownId: null });
   }
 }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -378,11 +378,15 @@ export default class MultiDropDown extends BaseComponent {
   }
 
   keepFocus(elementId) {
-    this.setState({ focusedDropdownId: elementId });
+    if (!this.state || !this.state.focusedDropdownId || this.state.focusedDropdownId !== elementId) {
+      this.setState({ focusedDropdownId: elementId });
+    }
   }
 
   loseFocus() {
-    this.setState({ focusedDropdownId: null });
+    if (this.state.focusedDropdownId) {
+      this.setState({ focusedDropdownId: null });
+    }
   }
 }
 

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -178,6 +178,7 @@ export default class MultiDropDown extends BaseComponent {
 
 
       if(!!selAnswer && (!!correctAnswer && selAnswer.chosen_answer_id === correctAnswer.value)){
+        const altText = `Correct selection.  Feedback is listed under (${i}).`;
         answerCheck = (
           `<span
                 style="display:inline-block;"
@@ -189,13 +190,14 @@ export default class MultiDropDown extends BaseComponent {
                   height="20px"
                   src="/assets/correct.png"
                   style="${correctStyle}"
-                  alt="image to indicate the correct option was chosen"
+                  alt=${altText}
                   /> (${i})
               </span>
             </span>`
         );
       }
       else{
+        const altText = `Incorrect selection. Feeback is listed under (${i}).`
         answerCheck = (
           `<span
                 style="display:inline-block;"
@@ -207,7 +209,7 @@ export default class MultiDropDown extends BaseComponent {
                   height="20px"
                   src="/assets/incorrect.png"
                   style="${incorrectStyle}"
-                  alt="image to indicate the incorrect option was chosen"
+                  alt=${altText}
                 /> (${i})
               </span>
             </span>`

--- a/client/js/components/common/multi_drop_down.jsx
+++ b/client/js/components/common/multi_drop_down.jsx
@@ -139,7 +139,7 @@ export default class MultiDropDown extends BaseComponent {
       }
 
       if ((this.props.isResult && !!correctAnswer) && correctAnswer.value !== answer.value) disabled = "disabled";
-      const describedby = (this.props.isResult) ? `aria-describedby=${answerDivId}` : ""
+      const describedby = (this.props.isResult) ? `aria-describedby=${answerDivId}` : "";
 
       return `<option ${selected} ${disabled} ${describedby} value=${answer.value}>${answer.name}</option>`;
     });

--- a/client/js/components/common/progress_dropdown.jsx
+++ b/client/js/components/common/progress_dropdown.jsx
@@ -13,6 +13,10 @@ export default class ProgressDropdown extends BaseComponent{
     this._bind("navButtonClicked", "getStyles", "handleKeyDown");
   }
 
+  componentDidMount() {
+    if(document.getElementById("focus")){document.getElementById("focus").focus();}
+  }
+
   navButtonClicked(e){
     if(this.state && this.state.expanded){
       this.setState({expanded: !this.state.expanded})

--- a/client/js/components/common/progress_dropdown.jsx
+++ b/client/js/components/common/progress_dropdown.jsx
@@ -110,7 +110,7 @@ export default class ProgressDropdown extends BaseComponent{
     var text = this.generateProgressText();
     return (
       <span onKeyDown={(e) => { this.handleKeyDown(e); }}>
-        <img style={styles.icon}src={this.props.settings.images.ProgressIcon_svg} />
+        <img style={styles.icon}src={this.props.settings.images.ProgressIcon_svg} alt="" />
         <button id="focus" style={styles.dropdownButton} className="btn" type="button" aria-haspopup="true" aria-controls="questionsMenu" aria-expanded={expanded ? true : false} onClick={(e) => { if(!this.props.disabled) { this.navButtonClicked(e); }}}>
           <div>Progress</div>
           <span>{text}</span>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -49,7 +49,10 @@ export default class RadioButton extends React.Component {
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>
-          {this.isQuizPage() ? this.answerFeedback() : ""}
+          <div aria-live="polite" role="region" aria-labelledby={"feedback"+this.props.index}>
+            <div style={this.props.visuallyHiddenStyle} id={"feedback"+this.props.index}>Feedback Region {this.props.index}</div>
+            {this.isQuizPage() ? this.answerFeedback() : ""}
+          </div>
         </div>
       </div>
     );
@@ -103,8 +106,7 @@ export default class RadioButton extends React.Component {
         <img
           src="/assets/correct.png"
           className="correctIndicator"
-          aria-label="Correct Answer"
-          alt="Icon indicating the correct answer was chosen"
+          alt="Correct"
           style={styles.checkStyleCorrect}
           />
       );
@@ -113,8 +115,7 @@ export default class RadioButton extends React.Component {
         <img
           src="/assets/incorrect.png"
           className="wrongIndicator"
-          aria-label="Wrong answer that was chosen"
-          alt="Icon indicating the wrong answer was chosen"
+          alt="Incorrect"
           style={styles.checkStyleWrong}
           />
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -49,8 +49,7 @@ export default class RadioButton extends React.Component {
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>
-          <div aria-live="polite" role="region" aria-labelledby={"feedback"+this.props.index}>
-            <div style={this.props.visuallyHiddenStyle} id={"feedback"+this.props.index}>Feedback Region {this.props.index}</div>
+          <div>
             {this.isQuizPage() ? this.answerFeedback() : ""}
           </div>
         </div>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -28,6 +28,7 @@ export default class RadioButton extends React.Component {
       disabled: this.props.isDisabled,
       name: this.props.name,
       id: this.props.id,
+      style: { float:"left",position:"absolute" },
       onClick: () => { this.answerSelected(); }
     };
     if (this.showIncorrectAndChecked()) {
@@ -46,14 +47,12 @@ export default class RadioButton extends React.Component {
       <div>
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={btnQuestionStyles}>
-          <span style={{display:"table-cell",verticalAlign:"top"}}>
+          <label>
             <input {...inputProps} />
-          </span>
-          <span style={{display:"table-cell",paddingLeft:"11px",fontWeight:"normal"}}>
-            <label htmlFor={this.props.id}
-                   style={{paddingLeft:"11px",fontWeight:"normal"}}
-                   dangerouslySetInnerHTML={{__html: this.props.item.material}} />
-          </span>
+            <span style={{display:"inline-block",paddingLeft:"25px",fontWeight:"normal"}}
+                dangerouslySetInnerHTML={{__html: this.props.item.material}}>
+            </span>
+          </label>
           <div>
             {this.isQuizPage() ? this.answerFeedback() : ""}
           </div>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -37,12 +37,25 @@ export default class RadioButton extends React.Component {
                 tabIndex="0"
                 />
             </span>
-            <span style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}} dangerouslySetInnerHTML={{__html: this.props.item.material}}/>
+            <span
+              style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
+              dangerouslySetInnerHTML={{__html: this.props.item.material}}
+              tabIndex={this.getTabIndex()}
+              />
           </label>
           {this.isQuizPage() ? this.answerFeedback() : ""}
         </div>
       </div>
     );
+  }
+
+  getTabIndex() {
+    // if question has been answered, add to tab order, otherwise ignore it.
+    if (this.props.showAsCorrect !== null && this.props.checked === true) {
+      return "0";
+    } else {
+      return -1;
+    }
   }
 
   getBtnQuestionStyles() {

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -150,14 +150,13 @@ export default class RadioButton extends React.Component {
           className="check_answer_result"
           style={this.getFeedbackStyles()}
           dangerouslySetInnerHTML={this.answerFeedbackMarkup()}
-          tabIndex="0"
           />
       );
     }
 
     if (this.showIncorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()} tabIndex="0">
+        <div className="check_answer_result" style={this.getFeedbackStyles()}>
           Incorrect
         </div>
       );
@@ -165,7 +164,7 @@ export default class RadioButton extends React.Component {
 
     if (this.showCorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()} tabIndex="0">
+        <div className="check_answer_result" style={this.getFeedbackStyles()}>
           Correct
         </div>
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -25,16 +25,16 @@ export default class RadioButton extends React.Component {
     return (
       <div>
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={btnQuestionStyles}>
-          <label style={this.getButtonLabelStyles()}>
-            <span style={{display: "table-cell"}}>
+        <div className="btn btn-block btn-question" style={btnQuestionStyles} tabIndex={-1}>
+          <label style={this.getButtonLabelStyles()} tabIndex={-1}>
+            <span style={{display: "table-cell"}} tabIndex={-1}>
               <input
                 type="radio"
                 defaultChecked={this.checkedStatus()}
                 disabled={this.props.isDisabled}
                 name={this.props.name}
                 onClick={() => { this.answerSelected(); }}
-                tabIndex="0"
+                tabIndex={this.getReverseTabIndex()}
                 />
             </span>
             <span
@@ -51,10 +51,19 @@ export default class RadioButton extends React.Component {
 
   getTabIndex() {
     // if question has been answered, add to tab order, otherwise ignore it.
-    if (this.props.showAsCorrect !== null && this.props.checked === true) {
+    if (this.props.showAsCorrect !== null) {
       return "0";
     } else {
       return -1;
+    }
+  }
+
+  getReverseTabIndex() {
+    // if question has been answered, remove from tab order, otherwise add it.
+    if (this.props.showAsCorrect !== null) {
+      return -1;
+    } else {
+      return "0";
     }
   }
 

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -117,6 +117,7 @@ export default class RadioButton extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer"
           alt="Icon indicating the correct answer was chosen"
+          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -127,6 +128,7 @@ export default class RadioButton extends React.Component {
           className="wrongIndicator"
           aria-label="Wrong answer that was chosen"
           alt="Icon indicating the wrong answer was chosen"
+          tabIndex="0"
           style={styles.checkStyleWrong}
           />
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -25,46 +25,26 @@ export default class RadioButton extends React.Component {
     return (
       <div>
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={btnQuestionStyles} tabIndex={-1}>
-          <label style={this.getButtonLabelStyles()} tabIndex={-1}>
-            <span style={{display: "table-cell"}} tabIndex={-1}>
+        <div className="btn btn-block btn-question" style={btnQuestionStyles}>
+          <label style={this.getButtonLabelStyles()}>
+            <span style={{display: "table-cell"}}>
               <input
                 type="radio"
                 defaultChecked={this.checkedStatus()}
                 disabled={this.props.isDisabled}
                 name={this.props.name}
                 onClick={() => { this.answerSelected(); }}
-                tabIndex={this.getReverseTabIndex()}
                 />
             </span>
             <span
               style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
-              tabIndex={this.getTabIndex()}
               />
           </label>
           {this.isQuizPage() ? this.answerFeedback() : ""}
         </div>
       </div>
     );
-  }
-
-  getTabIndex() {
-    // if question has been answered, add to tab order, otherwise ignore it.
-    if (this.props.showAsCorrect !== null) {
-      return "0";
-    } else {
-      return -1;
-    }
-  }
-
-  getReverseTabIndex() {
-    // if question has been answered, remove from tab order, otherwise add it.
-    if (this.props.showAsCorrect !== null) {
-      return -1;
-    } else {
-      return "0";
-    }
   }
 
   getBtnQuestionStyles() {
@@ -117,7 +97,6 @@ export default class RadioButton extends React.Component {
           className="correctIndicator"
           aria-label="Correct Answer"
           alt="Icon indicating the correct answer was chosen"
-          tabIndex="0"
           style={styles.checkStyleCorrect}
           />
       );
@@ -128,7 +107,6 @@ export default class RadioButton extends React.Component {
           className="wrongIndicator"
           aria-label="Wrong answer that was chosen"
           alt="Icon indicating the wrong answer was chosen"
-          tabIndex="0"
           style={styles.checkStyleWrong}
           />
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -22,19 +22,27 @@ export default class RadioButton extends React.Component {
      *
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
+    const inputProps = {
+      type: "radio",
+      defaultChecked: this.checkedStatus(),
+      disabled: this.props.isDisabled,
+      name: this.props.name,
+      onClick: () => { this.answerSelected(); }
+    };
+    if (this.showIncorrectAndChecked()) {
+      inputProps["aria-invalid"] = true;
+      inputProps["aria-describedby"] = this.feedbackId();
+    } else if (this.showCorrectAndChecked()) {
+      inputProps["aria-invalid"] = false;
+      inputProps["aria-describedby"] = this.feedbackId();
+    }
     return (
       <div>
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={btnQuestionStyles}>
           <label style={this.getButtonLabelStyles()}>
             <span style={{display: "table-cell"}}>
-              <input
-                type="radio"
-                defaultChecked={this.checkedStatus()}
-                disabled={this.props.isDisabled}
-                name={this.props.name}
-                onClick={() => { this.answerSelected(); }}
-                />
+              <input {...inputProps} />
             </span>
             <span
               style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
@@ -121,6 +129,10 @@ export default class RadioButton extends React.Component {
     }
   }
 
+  feedbackId() {
+    return this.props.id + "Hint";
+  }
+
   answerFeedback() {
     /**
      * Note on dangerouslySetInnerHTML Usage
@@ -136,6 +148,7 @@ export default class RadioButton extends React.Component {
     if (this.props.answerFeedback) {
       return (
         <div
+          id={this.feedbackId()}
           className="check_answer_result"
           style={this.getFeedbackStyles()}
           dangerouslySetInnerHTML={this.answerFeedbackMarkup()}
@@ -145,7 +158,7 @@ export default class RadioButton extends React.Component {
 
     if (this.showIncorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()}>
+        <div id={this.feedbackId()}  className="check_answer_result" style={this.getFeedbackStyles()}>
           Incorrect
         </div>
       );
@@ -153,7 +166,7 @@ export default class RadioButton extends React.Component {
 
     if (this.showCorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()}>
+        <div id={this.feedbackId()}  className="check_answer_result" style={this.getFeedbackStyles()}>
           Correct
         </div>
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -28,7 +28,14 @@ export default class RadioButton extends React.Component {
         <div className="btn btn-block btn-question" style={btnQuestionStyles}>
           <label style={this.getButtonLabelStyles()}>
             <span style={{display: "table-cell"}}>
-              <input type="radio" defaultChecked={this.checkedStatus()} disabled={this.props.isDisabled} name={this.props.name} onClick={() => { this.answerSelected(); }} />
+              <input
+                type="radio"
+                defaultChecked={this.checkedStatus()}
+                disabled={this.props.isDisabled}
+                name={this.props.name}
+                onClick={() => { this.answerSelected(); }}
+                tabIndex="0"
+                />
             </span>
             <span style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}} dangerouslySetInnerHTML={{__html: this.props.item.material}}/>
           </label>
@@ -130,13 +137,14 @@ export default class RadioButton extends React.Component {
           className="check_answer_result"
           style={this.getFeedbackStyles()}
           dangerouslySetInnerHTML={this.answerFeedbackMarkup()}
+          tabIndex="0"
           />
       );
     }
 
     if (this.showIncorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()}>
+        <div className="check_answer_result" style={this.getFeedbackStyles()} tabIndex="0">
           Incorrect
         </div>
       );
@@ -144,7 +152,7 @@ export default class RadioButton extends React.Component {
 
     if (this.showCorrectAndChecked()) {
       return (
-        <div className="check_answer_result" style={this.getFeedbackStyles()}>
+        <div className="check_answer_result" style={this.getFeedbackStyles()} tabIndex="0">
           Correct
         </div>
       );

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -36,6 +36,11 @@ export default class RadioButton extends React.Component {
       inputProps["aria-invalid"] = false;
       inputProps["aria-describedby"] = this.feedbackId();
     }
+    if (this.props.addRef) {
+      inputProps["ref"] = (node) => {
+        this.props.setRef(node);
+      };
+    }
     return (
       <div>
         {this.renderAnswerIndicator()}

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -27,6 +27,7 @@ export default class RadioButton extends React.Component {
       defaultChecked: this.checkedStatus(),
       disabled: this.props.isDisabled,
       name: this.props.name,
+      id: this.props.id,
       onClick: () => { this.answerSelected(); }
     };
     if (this.showIncorrectAndChecked()) {
@@ -45,15 +46,14 @@ export default class RadioButton extends React.Component {
       <div>
         {this.renderAnswerIndicator()}
         <div className="btn btn-block btn-question" style={btnQuestionStyles}>
-          <label style={this.getButtonLabelStyles()}>
-            <span style={{display: "table-cell"}}>
-              <input {...inputProps} />
-            </span>
-            <span
-              style={{display: "table-cell", paddingLeft: "11px", fontWeight: "normal"}}
-              dangerouslySetInnerHTML={{__html: this.props.item.material}}
-              />
-          </label>
+          <span style={{display:"table-cell",verticalAlign:"top"}}>
+            <input {...inputProps} />
+          </span>
+          <span style={{display:"table-cell",paddingLeft:"11px",fontWeight:"normal"}}>
+            <label htmlFor={this.props.id}
+                   style={{paddingLeft:"11px",fontWeight:"normal"}}
+                   dangerouslySetInnerHTML={{__html: this.props.item.material}} />
+          </span>
           <div>
             {this.isQuizPage() ? this.answerFeedback() : ""}
           </div>
@@ -63,13 +63,13 @@ export default class RadioButton extends React.Component {
   }
 
   getBtnQuestionStyles() {
-    let qStyles = styles.btnQuestion;
+    let qStyles = { ...styles.btnQuestion, padding: "11px 11px 6px" };
 
     if (this.isQuizPage()) {
       if (this.showCorrectAndChecked()) {
-        qStyles = {...styles.btnQuestion, ...styles.btnQuestionCorrect};
+        qStyles = {...styles.btnQuestion, ...styles.btnQuestionCorrect, padding: "11px 11px 6px"};
       } else if (this.showIncorrectAndChecked()) {
-        qStyles = {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
+        qStyles = {...styles.btnQuestion, ...styles.btnQuestionIncorrect, padding: "11px 11px 6px"};
       }
     }
 

--- a/client/js/components/common/text_area.jsx
+++ b/client/js/components/common/text_area.jsx
@@ -42,8 +42,8 @@ export default class TextArea extends React.Component{
      */
     if ((this.isFormative()) || this.isPractice() && this.props.completed) {
       return (
-        <div className="check_answer_result" style={styles.feedbackNeutral}>
-          <span dangerouslySetInnerHTML={this.renderCustomFeedback(this.props.item.feedback.general_fb)}></span>
+        <div className="check_answer_result" style={styles.feedbackNeutral} tabIndex="0">
+          <span dangerouslySetInnerHTML={this.renderCustomFeedback(this.props.item.feedback.general_fb)} />
         </div>
       );
     }

--- a/client/js/components/common/text_area.jsx
+++ b/client/js/components/common/text_area.jsx
@@ -23,7 +23,9 @@ export default class TextArea extends React.Component{
           defaultValue={this.props.initialText}
           disabled={this.props.isDisabled}
           />
-          {this.answerFeedback()}
+          <div aria-live="polite">
+            {this.answerFeedback()}
+          </div>
       </div>
     );
   }

--- a/client/js/components/main/assessment.jsx
+++ b/client/js/components/main/assessment.jsx
@@ -131,7 +131,6 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
-        console.log("new graded question previous, updating state");
         this.setState({newQuestion: true});
       });
     } else {
@@ -140,7 +139,6 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
-      console.log("new ungraded question previous, updating state");
       this.setState({newQuestion: true});
     }
   }
@@ -155,7 +153,6 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
-        console.log("new graded question next, updating state");
         this.setState({newQuestion: true});
       });
     } else {
@@ -164,7 +161,6 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
-      console.log("new ungraded question next, updating state");
       this.setState({newQuestion: true});
     }
   }

--- a/client/js/components/main/assessment.jsx
+++ b/client/js/components/main/assessment.jsx
@@ -107,7 +107,6 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
-        this.setState({questionSelected: true, newQuestion: true});
       });
     } else {
       AssessmentActions.selectQuestion(qid);
@@ -115,7 +114,6 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
-      this.setState({newQuestion: true});
     }
   }
 
@@ -133,6 +131,7 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
+        console.log("new graded question previous, updating state");
         this.setState({newQuestion: true});
       });
     } else {
@@ -141,6 +140,7 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
+      console.log("new ungraded question previous, updating state");
       this.setState({newQuestion: true});
     }
   }
@@ -155,6 +155,7 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
+        console.log("new graded question next, updating state");
         this.setState({newQuestion: true});
       });
     } else {
@@ -163,6 +164,7 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
+      console.log("new ungraded question next, updating state");
       this.setState({newQuestion: true});
     }
   }

--- a/client/js/components/main/assessment.jsx
+++ b/client/js/components/main/assessment.jsx
@@ -46,7 +46,8 @@ export default class Assessment extends BaseComponent{
       studentAnswer        : AssessmentStore.studentAnswers(),
       allQuestions         : AssessmentStore.allQuestions(),
       outcomes             : AssessmentStore.outcomes(),
-      gradingCallback      : null
+      gradingCallback      : null,
+      newQuestion          : false
     }
   }
 
@@ -57,6 +58,12 @@ export default class Assessment extends BaseComponent{
       //AssessmentActions.assessmentViewed(this.state.settings, this.state.assessment);
     }
     window.addEventListener('load', this.materialLoaded);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.newQuestion) { // if last render caught newQuestion, then we've focused, so reset
+      this.setState({newQuestion: false});
+    }
   }
 
   componentWillUnmount(){
@@ -100,7 +107,7 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
-        this.setState({questionSelected: true});
+        this.setState({questionSelected: true, newQuestion: true});
       });
     } else {
       AssessmentActions.selectQuestion(qid);
@@ -108,6 +115,7 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
+      this.setState({newQuestion: true});
     }
   }
 
@@ -125,6 +133,7 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
+        this.setState({newQuestion: true});
       });
     } else {
       AssessmentActions.previousQuestion();
@@ -132,6 +141,7 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
+      this.setState({newQuestion: true});
     }
   }
 
@@ -145,6 +155,7 @@ export default class Assessment extends BaseComponent{
           finishedCallback();
         }
         Assessment.newQuestionMessages();
+        this.setState({newQuestion: true});
       });
     } else {
       AssessmentActions.nextQuestion();
@@ -152,6 +163,7 @@ export default class Assessment extends BaseComponent{
         finishedCallback();
       }
       Assessment.newQuestionMessages();
+      this.setState({newQuestion: true});
     }
   }
 
@@ -198,6 +210,7 @@ export default class Assessment extends BaseComponent{
         outcomes         = {this.state.outcomes}
         resetAnswerMessages = {this.resetAnswerMessages}
         showAnswers = {this.state.settings.showAnswers}
+        newQuestion      = {this.state.newQuestion}
       />;
     }
 

--- a/public/401.html
+++ b/public/401.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Access denied (401)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
# Acceptance Criteria

As a non sighted user I need the Self Checks and Feedback to be fully accessible.

# Code Changes

These changes target the "formative" assessment type only (and anywhere the common "radio" and "checkbox" components are used).  `tabindex` has been added to several nodes, making assessments and feedback more traversable.