### PR TITLE
PROD 708: Don't display progress bar after quiz is submitted

### DIFF
--- a/client/js/components/main/assessment.jsx
+++ b/client/js/components/main/assessment.jsx
@@ -246,7 +246,7 @@ export default class Assessment extends BaseComponent{
   }
 
   renderProgressBar(styles) {
-    if (AssessmentStore.isFormative() || AssessmentStore.isPractice()) {
+    if (this.state.isSubmitted || AssessmentStore.isFormative() || AssessmentStore.isPractice()) {
       return;
     } else {
       return (


### PR DESCRIPTION
## Current situation:
Progress bar is loaded on all assessment pages and, on mount, receives focus. This was occurring even on the summary page, which meant screenreader users were hearing the final questions progress bar repeated.

The issue can be visually verified by using Chrome dev tools network throttling features:
![screen capture of issue](https://user-images.githubusercontent.com/2653980/67585849-6198e380-f71e-11e9-8c12-000f4e173d8d.gif)

### [Jira ticket](https://lumenlearning.atlassian.net/secure/RapidBoard.jspa?rapidView=35&projectKey=PROD&modal=detail&selectedIssue=PROD-708&quickFilter=66)

## Solution:
Don't display the progress bar if state matches `isSubmitted`. Again, network throttling shows this working:
![screen capture of solution](https://user-images.githubusercontent.com/2653980/67585935-81c8a280-f71e-11e9-905d-a67911b23592.gif)
