### PR TITLE
SUP-487 Checkbox and radio input fixes

### DIFF
--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -27,7 +27,7 @@ export default class CheckBox extends React.Component {
       type: "checkbox",
       defaultChecked: this.props.checked,
       name: this.props.name,
-      id: this.props.name,
+      id: this.props.id,
       onClick: () => { this.answerSelected(); }
     };
     if (this.selectedCorrectAnswer()) {

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -46,7 +46,7 @@ export default class CheckBox extends React.Component {
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
         <div style={this.getButtonQuestionStyles()}>
-          <label className="btn btn-block btn-question" style={btnLabelStyles}>
+          <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnLabelStyles}>
             <input { ...inputProps }/>
             <span
               style={{display: "inline-block", paddingLeft: "25px", fontWeight: "normal"}}

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -45,8 +45,8 @@ export default class CheckBox extends React.Component {
     return (
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={this.getButtonQuestionStyles()}>
-          <label style={btnLabelStyles}>
+        <div style={this.getButtonQuestionStyles()}>
+          <label className="btn btn-block btn-question" style={btnLabelStyles}>
             <input { ...inputProps }/>
             <span
               style={{display: "inline-block", paddingLeft: "25px", fontWeight: "normal"}}

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -23,7 +23,7 @@ export default class CheckBox extends React.Component {
      * READ: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
      */
     const inputProps = {
-      style: { margin: 0, float: "left", position: "absolute" },
+      style: { margin: 0, position: "absolute" },
       type: "checkbox",
       defaultChecked: this.props.checked,
       name: this.props.name,
@@ -49,7 +49,7 @@ export default class CheckBox extends React.Component {
           <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnLabelStyles}>
             <input { ...inputProps }/>
             <span
-              style={{display: "inline-block", paddingLeft: "25px", fontWeight: "normal"}}
+              style={{paddingLeft: "25px"}}
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -47,7 +47,7 @@ export default class RadioButton extends React.Component {
       <div>
         {this.renderAnswerIndicator()}
         <div>
-          <label className="btn btn-block btn-question" style={btnQuestionStyles}>
+          <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnQuestionStyles}>
             <input {...inputProps} />
             <span style={{display:"inline-block",paddingLeft:"25px",fontWeight:"normal"}}
                 dangerouslySetInnerHTML={{__html: this.props.item.material}}>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -28,7 +28,7 @@ export default class RadioButton extends React.Component {
       disabled: this.props.isDisabled,
       name: this.props.name,
       id: this.props.id,
-      style: { float:"left",position:"absolute" },
+      style: { position:"absolute" },
       onClick: () => { this.answerSelected(); }
     };
     if (this.showIncorrectAndChecked()) {
@@ -49,7 +49,7 @@ export default class RadioButton extends React.Component {
         <div>
           <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnQuestionStyles}>
             <input {...inputProps} />
-            <span style={{display:"inline-block",paddingLeft:"25px",fontWeight:"normal"}}
+            <span style={{paddingLeft:"25px"}}
                 dangerouslySetInnerHTML={{__html: this.props.item.material}}>
             </span>
           </label>

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -46,8 +46,8 @@ export default class RadioButton extends React.Component {
     return (
       <div>
         {this.renderAnswerIndicator()}
-        <div className="btn btn-block btn-question" style={btnQuestionStyles}>
-          <label>
+        <div>
+          <label className="btn btn-block btn-question" style={btnQuestionStyles}>
             <input {...inputProps} />
             <span style={{display:"inline-block",paddingLeft:"25px",fontWeight:"normal"}}
                 dangerouslySetInnerHTML={{__html: this.props.item.material}}>


### PR DESCRIPTION
## Current situation
Only the exact space of the input and its label is "clickable" by users.

## Solution
1. Move some of the styles from the surrounding `div` to the `label` element so the padding is on the clickable element, not surrounding it.

### Additional fixes applied
1. Make sure every label has a `for` attribute that connects it to its input.
1. Make sure the input IDs are unique.
1. Remove some inline styles that duplicate existing styles or are ineffective.