### PR TITLE
PROD-805 Update feedback on radio and checkbox questions

### DIFF
--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -9,7 +9,8 @@ const styles = Styles;
 
 export default class CheckBox extends React.Component {
   render() {
-    let btnLabelStyles = this.props.showAsCorrect !== null ? {...styles.btnLabel, ...{cursor: "default", padding: "11px 11px 6px"}} : {...styles.btnLabel, ...{cursor: "pointer", padding: "11px 11px 6px"}};
+    let btnQuestionStyles = this.getBtnQuestionStyles();
+    let btnLabelStyles = this.getBtnLabelStyles();
 
     /**
      * Note on dangerouslySetInnerHTML Usage
@@ -45,8 +46,8 @@ export default class CheckBox extends React.Component {
     return (
       <div className="checkbox-wrapper">
         {this.renderAnswerIndicator()}
-        <div style={this.getButtonQuestionStyles()}>
-          <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnLabelStyles}>
+        <div className="btn btn-block btn-question" style={btnQuestionStyles}>
+          <label htmlFor={inputProps["id"]} style={btnLabelStyles}>
             <input { ...inputProps }/>
             <span
               style={{paddingLeft: "25px"}}
@@ -116,26 +117,36 @@ export default class CheckBox extends React.Component {
     }
   }
 
-  getButtonQuestionStyles() {
+  getBtnQuestionStyles() {
+    let qStyles = { ...styles.btnQuestion };
+
     if (this.shouldShowAnswerFeedback()) {
-      return this.getButtonStyles();
+      if (this.selectedCorrectAnswer()) {
+        qStyles =  {...styles.btnQuestion, ...styles.btnQuestionCorrect};
+      } else if (this.unselectedCorrectAnswer()) {
+        qStyles =  {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
+      } else if (this.selectedIncorrectAnswer()) {
+        qStyles =  {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
+      } else {
+        qStyles =  {...styles.btnQuestion};
+      }
     }
 
-    return styles.btnQuestion;
+    return qStyles;
   }
 
-  getButtonStyles() {
-    if (this.selectedCorrectAnswer()) {
-      return {...styles.btnQuestion, ...styles.btnQuestionCorrect};
-    } else if (this.unselectedCorrectAnswer()) {
-      return {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
-    } else if (this.selectedIncorrectAnswer()) {
-      return {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
+  getBtnLabelStyles() {
+    let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
+
+    if (this.props.showAsCorrect !== null) {
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}}
     } else {
-      return styles.btnQuestion;
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}}
     }
-  }
 
+    return lStyles;
+  }
+  
   answerFeedback() {
     if (this.shouldShowAnswerFeedback()) {
       let feedback = this.getFeedback();

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -139,9 +139,9 @@ export default class CheckBox extends React.Component {
     let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
 
     if (this.props.showAsCorrect !== null) {
-      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}};
     } else {
-      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}};
     }
 
     return lStyles;

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -77,12 +77,12 @@ export default class RadioButton extends React.Component {
   }
 
   getBtnLabelStyles() {
-    let lStyles = {...styles.btnLabel, padding: "11px 11px 6px" };
+    let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
 
     if (this.props.showAsCorrect !== null) {
-      lStyles = {...styles.btnLabel, ...{cursor: "default", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}}
     } else {
-      lStyles = {...styles.btnLabel, ...{cursor: "pointer", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}}
     }
 
     return lStyles;

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -10,6 +10,7 @@ const styles = Styles;
 export default class RadioButton extends React.Component {
   render() {
     let btnQuestionStyles = this.getBtnQuestionStyles();
+    let btnLabelStyles = this.getBtnLabelStyles();
 
     /**
      * Note on dangerouslySetInnerHTML Usage
@@ -46,8 +47,8 @@ export default class RadioButton extends React.Component {
     return (
       <div>
         {this.renderAnswerIndicator()}
-        <div>
-          <label htmlFor={inputProps["id"]} className="btn btn-block btn-question" style={btnQuestionStyles}>
+        <div className="btn btn-block btn-question" style={btnQuestionStyles}>
+          <label htmlFor={inputProps["id"]} style={btnLabelStyles}>
             <input {...inputProps} />
             <span style={{paddingLeft:"25px"}}
                 dangerouslySetInnerHTML={{__html: this.props.item.material}}>
@@ -62,29 +63,29 @@ export default class RadioButton extends React.Component {
   }
 
   getBtnQuestionStyles() {
-    let qStyles = { ...styles.btnQuestion, padding: "11px 11px 6px" };
+    let qStyles = { ...styles.btnQuestion };
 
     if (this.isQuizPage()) {
       if (this.showCorrectAndChecked()) {
-        qStyles = {...styles.btnQuestion, ...styles.btnQuestionCorrect, padding: "11px 11px 6px"};
+        qStyles = {...styles.btnQuestion, ...styles.btnQuestionCorrect};
       } else if (this.showIncorrectAndChecked()) {
-        qStyles = {...styles.btnQuestion, ...styles.btnQuestionIncorrect, padding: "11px 11px 6px"};
+        qStyles = {...styles.btnQuestion, ...styles.btnQuestionIncorrect};
       }
     }
 
     return qStyles;
   }
 
-  getButtonLabelStyles() {
+  getBtnLabelStyles() {
+    let lStyles = {...styles.btnLabel, padding: "11px 11px 6px" };
+
     if (this.props.showAsCorrect !== null) {
-      return (
-        {...styles.btnLabel, ...{cursor: "default", padding: "11px 11px 6px"}}
-      );
+      lStyles = {...styles.btnLabel, ...{cursor: "default", padding: "11px 11px 6px"}}
     } else {
-      return (
-        {...styles.btnLabel, ...{cursor: "pointer", padding: "11px 11px 6px"}}
-      );
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", padding: "11px 11px 6px"}}
     }
+
+    return lStyles;
   }
 
   isQuizPage() {

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -80,9 +80,9 @@ export default class RadioButton extends React.Component {
     let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
 
     if (this.props.showAsCorrect !== null) {
-      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}};
     } else {
-      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}}
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}};
     }
 
     return lStyles;


### PR DESCRIPTION
PR #94 originally sought to fix this bug, but changed the original quiz behavior. This PR
- moves the feedback back inside the question border and background color
- updates the components to use a similar style structure; I've no opinion on which way is better, but there was needless complexity in these two inputs handling styles so differently 🤷🏻‍♀️

## Updated screenshots
![Checkbox question with feedback shown](https://user-images.githubusercontent.com/2653980/68800791-c31ae680-0628-11ea-8804-79ad665decca.png)
![Radio input question with feedback shown](https://user-images.githubusercontent.com/2653980/68800794-c4e4aa00-0628-11ea-9468-b7ca549e6e0a.png)
