### PR TITLE
PROD-805 Update styles on button labels and spans

### DIFF
--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -50,7 +50,7 @@ export default class CheckBox extends React.Component {
           <label htmlFor={inputProps["id"]} style={btnLabelStyles}>
             <input { ...inputProps }/>
             <span
-              style={{paddingLeft: "25px"}}
+              style={{display:"inline-block", paddingLeft:"25px"}}
               dangerouslySetInnerHTML={{__html: this.props.item.material}}
               />
           </label>
@@ -139,9 +139,9 @@ export default class CheckBox extends React.Component {
     let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
 
     if (this.props.showAsCorrect !== null) {
-      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}};
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", fontWeight: "normal", padding: "11px 11px 6px"}};
     } else {
-      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}};
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", fontWeight: "normal", padding: "11px 11px 6px"}};
     }
 
     return lStyles;

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -50,7 +50,7 @@ export default class RadioButton extends React.Component {
         <div className="btn btn-block btn-question" style={btnQuestionStyles}>
           <label htmlFor={inputProps["id"]} style={btnLabelStyles}>
             <input {...inputProps} />
-            <span style={{paddingLeft:"25px"}}
+            <span style={{display:"inline-block", paddingLeft:"25px"}}
                 dangerouslySetInnerHTML={{__html: this.props.item.material}}>
             </span>
           </label>
@@ -77,12 +77,12 @@ export default class RadioButton extends React.Component {
   }
 
   getBtnLabelStyles() {
-    let lStyles = {...styles.btnLabel, ...{display: "block", padding: "11px 11px 6px"} };
+    let lStyles = {...styles.btnLabel, ...{display: "block", fontWeight: "normal", padding: "11px 11px 6px"} };
 
     if (this.props.showAsCorrect !== null) {
-      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", padding: "11px 11px 6px"}};
+      lStyles = {...styles.btnLabel, ...{cursor: "default", display: "block", fontWeight: "normal", padding: "11px 11px 6px"}};
     } else {
-      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", padding: "11px 11px 6px"}};
+      lStyles = {...styles.btnLabel, ...{cursor: "pointer", display: "block", fontWeight: "normal", padding: "11px 11px 6px"}};
     }
 
     return lStyles;


### PR DESCRIPTION
Style updates made based on QA feedback:
- Reset button labels to _not_ be bold
- Reset button text (`span`) to be inline-block and maintain spacing from the related inputs

# Screenshots from QA
![image](https://user-images.githubusercontent.com/2653980/68880174-c5d51480-06d8-11ea-81fe-fb2d3788b315.png)
![image](https://user-images.githubusercontent.com/2653980/68880194-ccfc2280-06d8-11ea-96d4-e7fb3cc5c7d0.png)
