### PR TITLE
OEA-3 Add maintenance banner and vars to display it

### DIFF
--- a/app/views/assessments/_assessment_setup.html.erb
+++ b/app/views/assessments/_assessment_setup.html.erb
@@ -21,7 +21,8 @@
     csrfToken: form_authenticity_token,
     jwt: jwt_token,
     images: client_images("Books.svg", "PersonWithBook.svg", "ProgressIcon.svg", "QuizIcon.svg","CheckMark.svg"),
-    show_answers: @show_answers
+    show_answers: @show_answers,
+    maintenance_time:  ENV['maintenance_time']
    }
 
    if @external_user_id

--- a/client/js/components/banner/banner.jsx
+++ b/client/js/components/banner/banner.jsx
@@ -1,9 +1,9 @@
 // Dependencies
 import React, {Component}   from "react";
-import moment from 'moment';
+import moment from "moment";
 import SettingsStore           from "../../stores/settings";
 // Sub-Components
-import WarningSvg           from '../common/svg/warning.svg.jsx';
+import WarningSvg           from "../common/svg/warning.svg.jsx";
 
 
 export default class Banner extends Component {
@@ -23,11 +23,11 @@ export default class Banner extends Component {
             let now = Date.now();
             const formatter = new Intl.DateTimeFormat(
                 undefined,
-                {timeZoneName: 'short'}
+                {timeZoneName: "short"}
             );
             let localTzObject = formatter.formatToParts(now).find(
                 function(item) {
-                    return item.type === "timeZoneName"
+                    return item.type === "timeZoneName";
                 }
             );
             let localTZ = localTzObject["value"];
@@ -56,7 +56,7 @@ export default class Banner extends Component {
         } else {
             return (
                 <div></div>
-            )
+            );
         }
     }
 }

--- a/client/js/components/banner/banner.jsx
+++ b/client/js/components/banner/banner.jsx
@@ -1,0 +1,62 @@
+// Dependencies
+import React, {Component}   from "react";
+import moment from 'moment';
+import SettingsStore           from "../../stores/settings";
+// Sub-Components
+import WarningSvg           from '../common/svg/warning.svg.jsx';
+
+
+export default class Banner extends Component {
+    render() {
+        // Banner takes a UTC datetime property formatted like so:
+        // "2020-03-04T20:00:00"
+        // for March 4, 2020, 20:00 UTC
+
+        if (SettingsStore.current().maintenance_time) {
+            let dt          = moment.utc(
+                SettingsStore.current().maintenance_time,
+                moment.ISO_8601
+            );
+            let date        = dt.format("MMMM D");
+            let utcTime     = dt.format("H:mm z");
+            let localTime   = moment(dt).local().format("h:mm A");
+            let now = Date.now();
+            const formatter = new Intl.DateTimeFormat(
+                undefined,
+                {timeZoneName: 'short'}
+            );
+            let localTzObject = formatter.formatToParts(now).find(
+                function(item) {
+                    return item.type === "timeZoneName"
+                }
+            );
+            let localTZ = localTzObject["value"];
+
+            return (
+                <div className="small-12 columns">
+                    <div style={{border: "1px solid #F5A623",
+                        borderRadius: "2px",
+                        display: "flex",
+                        marginBottom: "1.25rem",
+                        marginTop: "1.25rem",
+                        padding: "8px"}}
+                    >
+                        <WarningSvg
+                        color="#F5A623"
+                        width="24"
+                        height="24"
+                        />
+                        <p style={{color: "#222", margin: "0 0 0 0.625rem"}}>
+                            <strong>Maintenance:</strong>
+                            &nbsp;This course will be down for an update {date} at {localTime} {localTZ} ({utcTime} ). Quiz attempts started or submitted during this time may be lost.
+                        </p>
+                    </div>
+                </div>
+            );
+        } else {
+            return (
+                <div></div>
+            )
+        }
+    }
+}

--- a/client/js/components/common/svg/warning.svg.jsx
+++ b/client/js/components/common/svg/warning.svg.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component} from "react";
 
 export default class WarningSvg extends Component{
   constructor(props){
@@ -23,6 +23,6 @@ export default class WarningSvg extends Component{
             d="M12 17a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm0-9c.6 0 1 .4 1 1v6a1 1 0 0 1-2 0V9c0-.6.4-1 1-1z"/>
         </g>
       </svg>
-    )
+    );
   }
 }

--- a/client/js/components/common/svg/warning.svg.jsx
+++ b/client/js/components/common/svg/warning.svg.jsx
@@ -1,0 +1,28 @@
+import React, {Component} from 'react';
+
+export default class WarningSvg extends Component{
+  constructor(props){
+    super(props);
+
+  }
+
+  render(){
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg"
+           viewBox="0 0 24 24"
+           width={this.props.width}
+           height={this.props.height}
+           aria-hidden="true"
+           role="img">
+        <g
+          fill={this.props.color}
+          fill-rule="evenodd">
+          <path
+            d="M9.4 3.5l-8.2 14A3 3 0 0 0 3.7 22h16.6a3 3 0 0 0 2.5-4.5l-8.2-14a3 3 0 0 0-5.2 0zm3.1.6l.4.4 8.2 14a1 1 0 0 1-.8 1.5H3.7a1 1 0 0 1-.8-1.5l8.2-14a1 1 0 0 1 1.4-.4z"/>
+          <path
+            d="M12 17a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm0-9c.6 0 1 .4 1 1v6a1 1 0 0 1-2 0V9c0-.6.4-1 1-1z"/>
+        </g>
+      </svg>
+    )
+  }
+}

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -12,6 +12,7 @@ import AssessmentStore from "../../stores/assessment";
 import SettingsStore from "../../stores/settings";
 import ReviewAssessmentStore from "../../stores/review_assessment";
 //Subcomponents
+import Banner from "../banner/banner";
 import BaseComponent from "../base_component";
 import CheckUnderstanding from "../assessments/check_understanding";
 import FullPostNav from "../post_nav/full_post_nav.jsx";
@@ -60,6 +61,7 @@ export default class Start extends BaseComponent {
 
     return (
       <div className="assessment" style={styles.assessment}>
+        {this.renderBanner()}
         {this.renderTitleBar(styles)}
         <div className="section_list">
           <div className="section_container">
@@ -99,6 +101,14 @@ export default class Start extends BaseComponent {
 
   isSummative() {
     return this.state.settings.assessmentKind.toUpperCase() === "SUMMATIVE";
+  }
+
+  renderBanner() {
+    if (this.isSummative()) {
+      return (
+        <Banner />
+      )
+    }
   }
 
   renderTitleBar(styles) {

--- a/client/js/components/main/start.jsx
+++ b/client/js/components/main/start.jsx
@@ -107,7 +107,7 @@ export default class Start extends BaseComponent {
     if (this.isSummative()) {
       return (
         <Banner />
-      )
+      );
     }
   }
 

--- a/client/js/stores/settings.js
+++ b/client/js/stores/settings.js
@@ -79,7 +79,8 @@ function loadSettings(defaultSettings){
     questionCount      : defaultSettings.questionCount,
     userAssessmentId   : bestValue('user_assessment_id', 'UserAssessmentId'),
     iframe_resize_id   : defaultSettings.iframe_resize_id,
-    showAnswers        : defaultSettings.show_answers
+    showAnswers        : defaultSettings.show_answers,
+    maintenance_time   : defaultSettings.maintenance_time
   };
 
   if(!_settings.srcUrl && !_settings.offline){


### PR DESCRIPTION
## Description
- Based on an environmental variable, display a notification that the service will be down for maintenance.
- Use the env variable to display date and time, both in UTC and the user's local time.

#### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/OEA-3)

#### Friend of
[Goldi PR #350](https://github.com/lumenlearning/goldilocks/pull/350)

## Screenshots
![Screenshot of example maintenance banner](https://user-images.githubusercontent.com/2653980/73303158-e1ce5980-41e3-11ea-852f-2b8f2af4087c.png)

---

## New ENV variables

### `maintenance_time`
- `maintenance_time` must be set like so: `"2020-04-04T20:00:00"`
- if this variable is not present, no banner will display

---

## Checklist
- [ ] My change requires a change to the documentation. ❓
- [ ] I have updated the documentation accordingly.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have requested a review from at least one other dev

This code should probably get a test added down the road, but didn't want to hold it up since it's time sensitive.