### PR TITLE
OEA-6 Add screenreader-only CSS class

### DIFF
--- a/app/assets/stylesheets/bare.css.scss
+++ b/app/assets/stylesheets/bare.css.scss
@@ -16,3 +16,14 @@ body{
 .wrongAns option{
   background-color: #e0542b;
 }
+
+.u-sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  margin: -1px;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;  
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Adds [`u-sr-only` class from Lux](https://github.com/lumenlearning/lux/blob/master/src/styles/10_utilities/_sr-only.scss) to existing CSS in OEA.

### Motivation and Context
This class will allow quiz editors to add elements that are only experienced by screenreader users, without changing the existing UI for others.

#### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/OEA-6)
